### PR TITLE
fix(ip): reliably honor IP allow-list (O5 — precedence, normalization, proxy depth)

### DIFF
--- a/guard_core/core/checks/helpers.py
+++ b/guard_core/core/checks/helpers.py
@@ -1,5 +1,5 @@
 import re
-from ipaddress import ip_address, ip_network
+from ipaddress import ip_address
 from typing import Any
 from urllib.parse import urlparse
 
@@ -7,17 +7,11 @@ from guard_core.decorators.base import RouteConfig
 from guard_core.detection_result import DetectionResult
 from guard_core.models import SecurityConfig
 from guard_core.protocols.request_protocol import GuardRequest
-from guard_core.utils import detect_penetration_attempt
+from guard_core.utils import _ip_in_list, detect_penetration_attempt
 
 
 def is_ip_in_blacklist(client_ip: str, ip_addr: object, blacklist: list[str]) -> bool:
-    for blocked in blacklist:
-        if "/" in blocked:
-            if ip_addr in ip_network(blocked, strict=False):
-                return True
-        elif client_ip == blocked:
-            return True
-    return False
+    return _ip_in_list(ip_addr, client_ip, blacklist)
 
 
 def is_ip_in_whitelist(
@@ -25,14 +19,7 @@ def is_ip_in_whitelist(
 ) -> bool | None:
     if not whitelist:
         return None
-
-    for allowed in whitelist:
-        if "/" in allowed:
-            if ip_addr in ip_network(allowed, strict=False):
-                return True
-        elif client_ip == allowed:
-            return True
-    return False
+    return _ip_in_list(ip_addr, client_ip, whitelist)
 
 
 def check_country_access(
@@ -79,12 +66,14 @@ async def check_route_ip_access(
     try:
         ip_addr = ip_address(client_ip)
 
-        if _check_ip_blacklist(client_ip, ip_addr, route_config):
+        whitelist_result = _check_ip_whitelist(client_ip, ip_addr, route_config)
+        if whitelist_result is True:
+            return True
+        if whitelist_result is False:
             return False
 
-        whitelist_result = _check_ip_whitelist(client_ip, ip_addr, route_config)
-        if whitelist_result is not None:
-            return whitelist_result
+        if _check_ip_blacklist(client_ip, ip_addr, route_config):
+            return False
 
         country_result = check_country_access(
             client_ip, route_config, middleware.geo_ip_handler

--- a/guard_core/models.py
+++ b/guard_core/models.py
@@ -83,11 +83,20 @@ class SecurityConfig(BaseModel):
     )
 
     whitelist: list[str] | None = Field(
-        default=None, description="Allowed IP addresses or CIDR ranges"
+        default=None,
+        description=(
+            "Allowed IP addresses or CIDR ranges. A non-empty whitelist is "
+            "restrictive: only listed IPs pass the global IP check. An explicit "
+            "whitelist match overrides the blacklist; dynamic IP bans still apply."
+        ),
     )
 
     blacklist: list[str] = Field(
-        default_factory=list, description="Blocked IP addresses or CIDR ranges"
+        default_factory=list,
+        description=(
+            "Blocked IP addresses or CIDR ranges. Enforced ahead of country and "
+            "cloud-provider checks, but overridden by an explicit whitelist match."
+        ),
     )
 
     whitelist_countries: frozenset[str] = Field(

--- a/guard_core/sync/core/checks/helpers.py
+++ b/guard_core/sync/core/checks/helpers.py
@@ -1,5 +1,5 @@
 import re
-from ipaddress import ip_address, ip_network
+from ipaddress import ip_address
 from typing import Any
 from urllib.parse import urlparse
 
@@ -7,17 +7,11 @@ from guard_core.models import SecurityConfig
 from guard_core.sync.decorators.base import RouteConfig
 from guard_core.sync.detection_result import DetectionResult
 from guard_core.sync.protocols.request_protocol import SyncGuardRequest
-from guard_core.sync.utils import detect_penetration_attempt
+from guard_core.sync.utils import _ip_in_list, detect_penetration_attempt
 
 
 def is_ip_in_blacklist(client_ip: str, ip_addr: object, blacklist: list[str]) -> bool:
-    for blocked in blacklist:
-        if "/" in blocked:
-            if ip_addr in ip_network(blocked, strict=False):
-                return True
-        elif client_ip == blocked:
-            return True
-    return False
+    return _ip_in_list(ip_addr, client_ip, blacklist)
 
 
 def is_ip_in_whitelist(
@@ -25,14 +19,7 @@ def is_ip_in_whitelist(
 ) -> bool | None:
     if not whitelist:
         return None
-
-    for allowed in whitelist:
-        if "/" in allowed:
-            if ip_addr in ip_network(allowed, strict=False):
-                return True
-        elif client_ip == allowed:
-            return True
-    return False
+    return _ip_in_list(ip_addr, client_ip, whitelist)
 
 
 def check_country_access(
@@ -79,12 +66,14 @@ def check_route_ip_access(
     try:
         ip_addr = ip_address(client_ip)
 
-        if _check_ip_blacklist(client_ip, ip_addr, route_config):
+        whitelist_result = _check_ip_whitelist(client_ip, ip_addr, route_config)
+        if whitelist_result is True:
+            return True
+        if whitelist_result is False:
             return False
 
-        whitelist_result = _check_ip_whitelist(client_ip, ip_addr, route_config)
-        if whitelist_result is not None:
-            return whitelist_result
+        if _check_ip_blacklist(client_ip, ip_addr, route_config):
+            return False
 
         country_result = check_country_access(
             client_ip, route_config, middleware.geo_ip_handler

--- a/guard_core/sync/utils.py
+++ b/guard_core/sync/utils.py
@@ -154,8 +154,7 @@ def _extract_from_forwarded_header(forwarded_for: str, proxy_depth: int) -> str 
     ips = [ip.strip() for ip in forwarded_for.split(",")]
 
     if len(ips) >= proxy_depth:
-        client_ip_index = 0
-        return ips[client_ip_index]
+        return ips[-proxy_depth]
 
     return None
 
@@ -402,26 +401,30 @@ def check_ip_country(
     return is_blocked
 
 
+def _ip_in_list(ip_addr: Any, ip: str, entries: list[str] | None) -> bool:
+    if not entries:
+        return False
+    for entry in entries:
+        if "/" in entry:
+            if ip_addr in ip_network(entry, strict=False):
+                return True
+        else:
+            try:
+                if ip_addr == ip_address(entry):
+                    return True
+            except ValueError:
+                if ip == entry:
+                    return True
+    return False
+
+
 def _check_blacklist(ip_addr: Any, ip: str, config: Any) -> bool:
-    if config.blacklist:
-        for blocked in config.blacklist:
-            if "/" in blocked:
-                if ip_addr in ip_network(blocked, strict=False):
-                    return False
-            elif ip == blocked:
-                return False
-    return True
+    return not _ip_in_list(ip_addr, ip, config.blacklist)
 
 
 def _check_whitelist(ip_addr: Any, ip: str, config: Any) -> bool:
     if config.whitelist:
-        for allowed in config.whitelist:
-            if "/" in allowed:
-                if ip_addr in ip_network(allowed, strict=False):
-                    return True
-            elif ip == allowed:
-                return True
-        return False
+        return _ip_in_list(ip_addr, ip, config.whitelist)
     return True
 
 
@@ -453,10 +456,10 @@ def is_ip_allowed(
     try:
         ip_addr = ip_address(ip)
 
-        if not _check_blacklist(ip_addr, ip, config):
-            return False
-
-        if not _check_whitelist(ip_addr, ip, config):
+        if config.whitelist:
+            if not _check_whitelist(ip_addr, ip, config):
+                return False
+        elif not _check_blacklist(ip_addr, ip, config):
             return False
 
         if not _check_blocked_countries(ip, config, geo_ip_handler):

--- a/guard_core/utils.py
+++ b/guard_core/utils.py
@@ -154,8 +154,7 @@ def _extract_from_forwarded_header(forwarded_for: str, proxy_depth: int) -> str 
     ips = [ip.strip() for ip in forwarded_for.split(",")]
 
     if len(ips) >= proxy_depth:
-        client_ip_index = 0
-        return ips[client_ip_index]
+        return ips[-proxy_depth]
 
     return None
 
@@ -402,26 +401,30 @@ async def check_ip_country(
     return is_blocked
 
 
+def _ip_in_list(ip_addr: Any, ip: str, entries: list[str] | None) -> bool:
+    if not entries:
+        return False
+    for entry in entries:
+        if "/" in entry:
+            if ip_addr in ip_network(entry, strict=False):
+                return True
+        else:
+            try:
+                if ip_addr == ip_address(entry):
+                    return True
+            except ValueError:
+                if ip == entry:
+                    return True
+    return False
+
+
 async def _check_blacklist(ip_addr: Any, ip: str, config: Any) -> bool:
-    if config.blacklist:
-        for blocked in config.blacklist:
-            if "/" in blocked:
-                if ip_addr in ip_network(blocked, strict=False):
-                    return False
-            elif ip == blocked:
-                return False
-    return True
+    return not _ip_in_list(ip_addr, ip, config.blacklist)
 
 
 async def _check_whitelist(ip_addr: Any, ip: str, config: Any) -> bool:
     if config.whitelist:
-        for allowed in config.whitelist:
-            if "/" in allowed:
-                if ip_addr in ip_network(allowed, strict=False):
-                    return True
-            elif ip == allowed:
-                return True
-        return False
+        return _ip_in_list(ip_addr, ip, config.whitelist)
     return True
 
 
@@ -453,10 +456,10 @@ async def is_ip_allowed(
     try:
         ip_addr = ip_address(ip)
 
-        if not await _check_blacklist(ip_addr, ip, config):
-            return False
-
-        if not await _check_whitelist(ip_addr, ip, config):
+        if config.whitelist:
+            if not await _check_whitelist(ip_addr, ip, config):
+                return False
+        elif not await _check_blacklist(ip_addr, ip, config):
             return False
 
         if not await _check_blocked_countries(ip, config, geo_ip_handler):

--- a/tests/test_sync/test_whitelist_correctness.py
+++ b/tests/test_sync/test_whitelist_correctness.py
@@ -1,0 +1,107 @@
+from ipaddress import ip_address
+from unittest.mock import MagicMock
+
+from guard_core.models import SecurityConfig
+from guard_core.sync.core.checks.helpers import (
+    check_route_ip_access,
+    is_ip_in_blacklist,
+    is_ip_in_whitelist,
+)
+from guard_core.sync.decorators.base import RouteConfig
+from guard_core.sync.utils import extract_client_ip, is_ip_allowed
+from tests.test_sync.conftest import SyncMockGuardRequest
+
+
+def test_whitelist_overrides_blacklist_exact() -> None:
+    config = SecurityConfig(whitelist=["1.2.3.4"], blacklist=["1.2.3.4"])
+    assert is_ip_allowed("1.2.3.4", config) is True
+
+
+def test_whitelist_overrides_blacklist_cidr() -> None:
+    config = SecurityConfig(whitelist=["10.0.0.0/8"], blacklist=["10.0.0.0/8"])
+    assert is_ip_allowed("10.1.2.3", config) is True
+
+
+def test_restrictive_whitelist_blocks_unlisted() -> None:
+    config = SecurityConfig(whitelist=["1.2.3.4"])
+    assert is_ip_allowed("5.6.7.8", config) is False
+
+
+def test_blacklist_enforced_without_whitelist() -> None:
+    config = SecurityConfig(blacklist=["1.2.3.4"])
+    assert is_ip_allowed("1.2.3.4", config) is False
+
+
+def test_whitelist_ipv6_compact_matches_expanded_client() -> None:
+    config = SecurityConfig(whitelist=["::1"])
+    assert is_ip_allowed("0:0:0:0:0:0:0:1", config) is True
+
+
+def test_blacklist_ipv6_expanded_matches_compact_client() -> None:
+    config = SecurityConfig(blacklist=["2001:db8::1"])
+    assert is_ip_allowed("2001:0db8:0000:0000:0000:0000:0000:0001", config) is False
+
+
+def test_route_whitelist_overrides_blacklist() -> None:
+    route_config = RouteConfig()
+    route_config.ip_whitelist = ["1.2.3.4"]
+    route_config.ip_blacklist = ["1.2.3.4"]
+    middleware = MagicMock()
+    middleware.geo_ip_handler = None
+    assert check_route_ip_access("1.2.3.4", route_config, middleware) is True
+
+
+def test_route_whitelist_ipv6_parsed_equality() -> None:
+    route_config = RouteConfig()
+    route_config.ip_whitelist = ["::1"]
+    route_config.ip_blacklist = []
+    middleware = MagicMock()
+    middleware.geo_ip_handler = None
+    assert check_route_ip_access("0:0:0:0:0:0:0:1", route_config, middleware) is True
+
+
+def test_is_ip_in_whitelist_ipv6_parsed_equality() -> None:
+    assert (
+        is_ip_in_whitelist("0:0:0:0:0:0:0:1", ip_address("0:0:0:0:0:0:0:1"), ["::1"])
+        is True
+    )
+
+
+def test_is_ip_in_blacklist_ipv6_parsed_equality() -> None:
+    expanded = "2001:0db8:0000:0000:0000:0000:0000:0001"
+    assert is_ip_in_blacklist(expanded, ip_address(expanded), ["2001:db8::1"]) is True
+
+
+def test_extract_client_ip_ignores_spoofed_xff_prefix() -> None:
+    config = SecurityConfig(trusted_proxies=["127.0.0.1"])
+    request = SyncMockGuardRequest(
+        path="/",
+        method="GET",
+        headers={"X-Forwarded-For": "9.9.9.9, 1.2.3.4"},
+        client_host="127.0.0.1",
+    )
+    assert extract_client_ip(request, config) == "1.2.3.4"
+
+
+def test_extract_client_ip_depth2_ignores_spoofed_prefix() -> None:
+    config = SecurityConfig(trusted_proxies=["127.0.0.1"], trusted_proxy_depth=2)
+    request = SyncMockGuardRequest(
+        path="/",
+        method="GET",
+        headers={"X-Forwarded-For": "9.9.9.9, 1.2.3.4, 5.5.5.5"},
+        client_host="127.0.0.1",
+    )
+    assert extract_client_ip(request, config) == "1.2.3.4"
+
+
+def test_global_and_route_agree_on_ipv6_whitelist_match() -> None:
+    config = SecurityConfig(whitelist=["::1"])
+    route_config = RouteConfig()
+    route_config.ip_whitelist = ["::1"]
+    middleware = MagicMock()
+    middleware.geo_ip_handler = None
+
+    global_allowed = is_ip_allowed("0:0:0:0:0:0:0:1", config)
+    route_allowed = check_route_ip_access("0:0:0:0:0:0:0:1", route_config, middleware)
+    assert global_allowed is True
+    assert route_allowed is True

--- a/tests/test_whitelist_correctness.py
+++ b/tests/test_whitelist_correctness.py
@@ -1,0 +1,113 @@
+from ipaddress import ip_address
+from unittest.mock import MagicMock
+
+from guard_core.core.checks.helpers import (
+    check_route_ip_access,
+    is_ip_in_blacklist,
+    is_ip_in_whitelist,
+)
+from guard_core.decorators.base import RouteConfig
+from guard_core.models import SecurityConfig
+from guard_core.utils import extract_client_ip, is_ip_allowed
+from tests.conftest import MockGuardRequest
+
+
+async def test_whitelist_overrides_blacklist_exact() -> None:
+    config = SecurityConfig(whitelist=["1.2.3.4"], blacklist=["1.2.3.4"])
+    assert await is_ip_allowed("1.2.3.4", config) is True
+
+
+async def test_whitelist_overrides_blacklist_cidr() -> None:
+    config = SecurityConfig(whitelist=["10.0.0.0/8"], blacklist=["10.0.0.0/8"])
+    assert await is_ip_allowed("10.1.2.3", config) is True
+
+
+async def test_restrictive_whitelist_blocks_unlisted() -> None:
+    config = SecurityConfig(whitelist=["1.2.3.4"])
+    assert await is_ip_allowed("5.6.7.8", config) is False
+
+
+async def test_blacklist_enforced_without_whitelist() -> None:
+    config = SecurityConfig(blacklist=["1.2.3.4"])
+    assert await is_ip_allowed("1.2.3.4", config) is False
+
+
+async def test_whitelist_ipv6_compact_matches_expanded_client() -> None:
+    config = SecurityConfig(whitelist=["::1"])
+    assert await is_ip_allowed("0:0:0:0:0:0:0:1", config) is True
+
+
+async def test_blacklist_ipv6_expanded_matches_compact_client() -> None:
+    config = SecurityConfig(blacklist=["2001:db8::1"])
+    assert (
+        await is_ip_allowed("2001:0db8:0000:0000:0000:0000:0000:0001", config) is False
+    )
+
+
+async def test_route_whitelist_overrides_blacklist() -> None:
+    route_config = RouteConfig()
+    route_config.ip_whitelist = ["1.2.3.4"]
+    route_config.ip_blacklist = ["1.2.3.4"]
+    middleware = MagicMock()
+    middleware.geo_ip_handler = None
+    assert await check_route_ip_access("1.2.3.4", route_config, middleware) is True
+
+
+async def test_route_whitelist_ipv6_parsed_equality() -> None:
+    route_config = RouteConfig()
+    route_config.ip_whitelist = ["::1"]
+    route_config.ip_blacklist = []
+    middleware = MagicMock()
+    middleware.geo_ip_handler = None
+    assert (
+        await check_route_ip_access("0:0:0:0:0:0:0:1", route_config, middleware) is True
+    )
+
+
+async def test_is_ip_in_whitelist_ipv6_parsed_equality() -> None:
+    assert (
+        is_ip_in_whitelist("0:0:0:0:0:0:0:1", ip_address("0:0:0:0:0:0:0:1"), ["::1"])
+        is True
+    )
+
+
+async def test_is_ip_in_blacklist_ipv6_parsed_equality() -> None:
+    expanded = "2001:0db8:0000:0000:0000:0000:0000:0001"
+    assert is_ip_in_blacklist(expanded, ip_address(expanded), ["2001:db8::1"]) is True
+
+
+async def test_extract_client_ip_ignores_spoofed_xff_prefix() -> None:
+    config = SecurityConfig(trusted_proxies=["127.0.0.1"])
+    request = MockGuardRequest(
+        path="/",
+        method="GET",
+        headers={"X-Forwarded-For": "9.9.9.9, 1.2.3.4"},
+        client_host="127.0.0.1",
+    )
+    assert await extract_client_ip(request, config) == "1.2.3.4"
+
+
+async def test_extract_client_ip_depth2_ignores_spoofed_prefix() -> None:
+    config = SecurityConfig(trusted_proxies=["127.0.0.1"], trusted_proxy_depth=2)
+    request = MockGuardRequest(
+        path="/",
+        method="GET",
+        headers={"X-Forwarded-For": "9.9.9.9, 1.2.3.4, 5.5.5.5"},
+        client_host="127.0.0.1",
+    )
+    assert await extract_client_ip(request, config) == "1.2.3.4"
+
+
+async def test_global_and_route_agree_on_ipv6_whitelist_match() -> None:
+    config = SecurityConfig(whitelist=["::1"])
+    route_config = RouteConfig()
+    route_config.ip_whitelist = ["::1"]
+    middleware = MagicMock()
+    middleware.geo_ip_handler = None
+
+    global_allowed = await is_ip_allowed("0:0:0:0:0:0:0:1", config)
+    route_allowed = await check_route_ip_access(
+        "0:0:0:0:0:0:0:1", route_config, middleware
+    )
+    assert global_allowed is True
+    assert route_allowed is True


### PR DESCRIPTION
**Stacked on #22** (base = `fix/sync-mirror-parity`). Merge #22 first; GitHub will retarget this to `master`. O5 needs #22's fixed unasync generator so the sync mirror regenerates correctly.

## What
Design-partner (high-traffic auth proxy) reported the IP allow-list was "not working" — allow-listed IPs/CIDRs weren't reliably honored. Root causes confirmed in source and fixed:

- **Precedence** — `is_ip_allowed` checked the blacklist *before* the whitelist, so a whitelisted IP also inside a blacklisted CIDR was blocked. Now an **explicit whitelist match overrides the blacklist**; dynamic IP bans (checked earlier in `ip_security.check`) **still win**. Same reorder applied to the route path (`check_route_ip_access`).
- **Normalization** — bare-IP matching used raw string equality (`ip == entry`), so IPv6 compact vs expanded (`::1` vs `0:0:0:0:0:0:0:1`) silently failed to match. Now compared via parsed `ip_address()` equality.
- **Consolidation** — the global (`utils.py`) and route (`helpers.py`) matchers now share one primitive, `utils._ip_in_list`, so they can't drift.
- **Proxy IP** — `_extract_from_forwarded_header` returned `ips[0]` (the spoofable leftmost `X-Forwarded-For` value) regardless of `trusted_proxy_depth`. Now returns the `trusted_proxy_depth`-th entry from the right.
- **Docs** — whitelist/blacklist precedence documented in the `SecurityConfig` field descriptions.

## Decisions (confirmed with maintainer)
- Whitelist **>** blacklist; dynamic bans still win.
- Proxy-depth client-IP gap **in scope**.

## Verification
- 13 new tests (`tests/test_whitelist_correctness.py`); the generated sync mirror runs the same suite, proving async/sync parity.
- Full async suite 1817 passed · full sync suite 1825 passed · existing `test_ip_security_edge_cases.py` and proxy tests still green.
- All pre-commit gates green (ruff-format / ruff / mypy / vulture / bandit / radon / xenon / deptry / check-sync).

## Scope
guard-core only. No new config fields or public API surface. Whitelist override is limited to the blacklist (country/cloud behavior unchanged).