### PR TITLE
feat(cloud): region/scope granularity for cloud-IP blocking (O6)

### DIFF
--- a/guard_core/core/initialization/handler_initializer.py
+++ b/guard_core/core/initialization/handler_initializer.py
@@ -124,7 +124,7 @@ class HandlerInitializer:
             try:
                 await cloud_handler.initialize_redis(
                     self.redis_handler,
-                    cast(set[str], self.config.block_cloud_providers),
+                    self.config.block_cloud_providers,
                     ttl=self.config.cloud_ip_refresh_interval,
                 )
             except Exception as e:
@@ -169,7 +169,7 @@ class HandlerInitializer:
             if self.config.block_cloud_providers:
                 await cloud_handler.initialize_redis(
                     self.redis_handler,
-                    cast(set[str], self.config.block_cloud_providers),
+                    self.config.block_cloud_providers,
                     ttl=self.config.cloud_ip_refresh_interval,
                 )
             if self.geo_ip_handler is not None:

--- a/guard_core/decorators/access_control.py
+++ b/guard_core/decorators/access_control.py
@@ -1,9 +1,9 @@
 import logging
 from collections.abc import Callable
-from typing import Any, cast
+from typing import Any
 
 from guard_core.decorators.base import BaseSecurityMixin, DecoratedFunction
-from guard_core.models import VALID_CLOUD_PROVIDERS, CloudProvider
+from guard_core.models import VALID_CLOUD_PROVIDERS
 
 
 class AccessControlMixin(BaseSecurityMixin):
@@ -48,12 +48,14 @@ class AccessControlMixin(BaseSecurityMixin):
         def decorator(func: Callable[..., Any]) -> DecoratedFunction:
             route_config = self._ensure_route_config(func)
             if providers is None:
-                route_config.block_cloud_providers = cast(
-                    set[CloudProvider], {"AWS", "GCP", "Azure"}
-                )
+                route_config.block_cloud_providers = {"AWS", "GCP", "Azure"}
             else:
-                valid = {p for p in providers if p in VALID_CLOUD_PROVIDERS}
-                route_config.block_cloud_providers = cast(set[CloudProvider], valid)
+                valid = {
+                    p
+                    for p in providers
+                    if p.partition(":!")[0] in VALID_CLOUD_PROVIDERS
+                }
+                route_config.block_cloud_providers = valid
                 invalid = set(providers) - valid
                 if invalid:
                     logging.getLogger("guard_core.decorators").warning(

--- a/guard_core/decorators/base.py
+++ b/guard_core/decorators/base.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from typing import Any, Protocol, cast, runtime_checkable
 
 from guard_core.handlers.behavior_handler import BehaviorRule, BehaviorTracker
-from guard_core.models import CloudProvider, SecurityConfig
+from guard_core.models import SecurityConfig
 from guard_core.protocols.request_protocol import GuardRequest
 
 
@@ -29,7 +29,7 @@ class RouteConfig:
         self.blocked_user_agents: list[str] = []
         self.required_headers: dict[str, str] = {}
         self.behavior_rules: list[BehaviorRule] = []
-        self.block_cloud_providers: set[CloudProvider] = set()
+        self.block_cloud_providers: set[str] = set()
         self.max_request_size: int | None = None
         self.allowed_content_types: list[str] | None = None
         self.time_restrictions: dict[str, str] | None = None

--- a/guard_core/handlers/cloud_handler.py
+++ b/guard_core/handlers/cloud_handler.py
@@ -13,7 +13,9 @@ from guard_core.protocols.cloud_ip_store_protocol import CloudIpStoreProtocol
 from guard_core.protocols.redis_protocol import RedisHandlerProtocol
 
 
-async def fetch_aws_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+async def fetch_aws_ip_ranges() -> tuple[
+    set[ipaddress.IPv4Network | ipaddress.IPv6Network], dict[str, str]
+]:
     try:
         async with aiohttp.ClientSession() as session:
             response = await session.get(
@@ -22,17 +24,25 @@ async def fetch_aws_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6Net
             )
             response.raise_for_status()
             data = await response.json(content_type=None)
-        return {
-            ipaddress.ip_network(ip_range["ip_prefix"])
-            for ip_range in data["prefixes"]
-            if ip_range["service"] == "AMAZON"
-        }
+        networks: set[ipaddress.IPv4Network | ipaddress.IPv6Network] = set()
+        regions: dict[str, str] = {}
+        for ip_range in data["prefixes"]:
+            if ip_range["service"] != "AMAZON":
+                continue
+            network = ipaddress.ip_network(ip_range["ip_prefix"])
+            networks.add(network)
+            region = ip_range.get("region")
+            if region:
+                regions[str(network)] = region
+        return networks, regions
     except Exception as e:
         logging.error(f"Failed to fetch AWS IP ranges: {str(e)}")
-        return set()
+        return set(), {}
 
 
-async def fetch_gcp_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+async def fetch_gcp_ip_ranges() -> tuple[
+    set[ipaddress.IPv4Network | ipaddress.IPv6Network], dict[str, str]
+]:
     try:
         async with aiohttp.ClientSession() as session:
             response = await session.get(
@@ -42,15 +52,20 @@ async def fetch_gcp_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6Net
             response.raise_for_status()
             data = await response.json(content_type=None)
         networks: set[ipaddress.IPv4Network | ipaddress.IPv6Network] = set()
+        regions: dict[str, str] = {}
         for ip_range in data["prefixes"]:
-            if "ipv4Prefix" in ip_range:
-                networks.add(ipaddress.ip_network(ip_range["ipv4Prefix"]))
-            elif "ipv6Prefix" in ip_range:
-                networks.add(ipaddress.ip_network(ip_range["ipv6Prefix"]))
-        return networks
+            prefix = ip_range.get("ipv4Prefix") or ip_range.get("ipv6Prefix")
+            if not prefix:
+                continue
+            network = ipaddress.ip_network(prefix)
+            networks.add(network)
+            scope = ip_range.get("scope")
+            if scope:
+                regions[str(network)] = scope
+        return networks, regions
     except Exception as e:
         logging.error(f"Failed to fetch GCP IP ranges: {str(e)}")
-        return set()
+        return set(), {}
 
 
 async def fetch_azure_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6Network]:
@@ -182,9 +197,66 @@ async def fetch_vultr_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6N
 _ALL_PROVIDERS = set({"AWS", "GCP", "Azure", "DigitalOcean", "Linode", "Vultr"})
 
 
+def _parse_cloud_selectors(
+    selectors: set[str],
+) -> tuple[set[str], dict[str, set[str]]]:
+    blocked: set[str] = set()
+    carveouts: dict[str, set[str]] = {}
+    for selector in selectors:
+        provider, marker, region = selector.partition(":!")
+        blocked.add(provider)
+        if marker and region:
+            carveouts.setdefault(provider, set()).add(region)
+    return blocked, carveouts
+
+
+async def _fetch_provider_ranges(
+    provider: str,
+) -> tuple[set[ipaddress.IPv4Network | ipaddress.IPv6Network], dict[str, str]]:
+    fetchers = {
+        "AWS": fetch_aws_ip_ranges,
+        "GCP": fetch_gcp_ip_ranges,
+        "Azure": fetch_azure_ip_ranges,
+        "DigitalOcean": fetch_digitalocean_ip_ranges,
+        "Linode": fetch_linode_ip_ranges,
+        "Vultr": fetch_vultr_ip_ranges,
+    }
+    result: Any = await fetchers[provider]()
+    if isinstance(result, tuple):
+        return result
+    return result, {}
+
+
+def _encode_cached(
+    ranges: set[ipaddress.IPv4Network | ipaddress.IPv6Network],
+    regions: dict[str, str],
+) -> set[str]:
+    encoded: set[str] = set()
+    for network in ranges:
+        key = str(network)
+        region = regions.get(key)
+        encoded.add(f"{key}|{region}" if region else key)
+    return encoded
+
+
+def _decode_cached(
+    entries: set[str],
+) -> tuple[set[ipaddress.IPv4Network | ipaddress.IPv6Network], dict[str, str]]:
+    networks: set[ipaddress.IPv4Network | ipaddress.IPv6Network] = set()
+    regions: dict[str, str] = {}
+    for entry in entries:
+        prefix, separator, region = entry.partition("|")
+        network = ipaddress.ip_network(prefix)
+        networks.add(network)
+        if separator and region:
+            regions[str(network)] = region
+    return networks, regions
+
+
 class CloudManager:
     _instance = None
     ip_ranges: dict[str, set[ipaddress.IPv4Network | ipaddress.IPv6Network]]
+    network_regions: dict[str, dict[str, str]]
     redis_handler: RedisHandlerProtocol | None = None
     agent_handler: AgentHandlerProtocol | None = None
     logger: logging.Logger
@@ -201,6 +273,9 @@ class CloudManager:
                 "DigitalOcean": set(),
                 "Linode": set(),
                 "Vultr": set(),
+            }
+            cls._instance.network_regions = {
+                provider: {} for provider in _ALL_PROVIDERS
             }
             cls._instance.last_updated = {provider: None for provider in _ALL_PROVIDERS}
             cls._instance.redis_handler = None
@@ -230,22 +305,17 @@ class CloudManager:
     async def _refresh_providers(self, providers: set[str] = _ALL_PROVIDERS) -> None:
         for provider in providers:
             try:
-                ranges = await {
-                    "AWS": fetch_aws_ip_ranges,
-                    "GCP": fetch_gcp_ip_ranges,
-                    "Azure": fetch_azure_ip_ranges,
-                    "DigitalOcean": fetch_digitalocean_ip_ranges,
-                    "Linode": fetch_linode_ip_ranges,
-                    "Vultr": fetch_vultr_ip_ranges,
-                }[provider]()
+                ranges, regions = await _fetch_provider_ranges(provider)
                 if ranges:
                     old_ranges = self.ip_ranges.get(provider, set())
                     self._log_range_changes(provider, old_ranges, ranges)
                     self.ip_ranges[provider] = ranges
+                    self.network_regions[provider] = regions
                     self.last_updated[provider] = datetime.now(timezone.utc)
             except Exception as e:
                 self.logger.error(f"Failed to fetch {provider} IP ranges: {str(e)}")
                 self.ip_ranges[provider] = set()
+                self.network_regions[provider] = {}
 
     async def initialize_redis(
         self,
@@ -279,27 +349,21 @@ class CloudManager:
             try:
                 cached = await self._store.get(provider)
                 if cached is not None:
-                    self.ip_ranges[provider] = {ipaddress.ip_network(s) for s in cached}
+                    nets, regions = _decode_cached(cached)
+                    self.ip_ranges[provider] = nets
+                    self.network_regions[provider] = regions
                     continue
 
-                fetch_func = {
-                    "AWS": fetch_aws_ip_ranges,
-                    "GCP": fetch_gcp_ip_ranges,
-                    "Azure": fetch_azure_ip_ranges,
-                    "DigitalOcean": fetch_digitalocean_ip_ranges,
-                    "Linode": fetch_linode_ip_ranges,
-                    "Vultr": fetch_vultr_ip_ranges,
-                }[provider]
-
-                ranges = await fetch_func()
+                ranges, regions = await _fetch_provider_ranges(provider)
                 if ranges:
                     old_ranges = self.ip_ranges.get(provider, set())
                     self._log_range_changes(provider, old_ranges, ranges)
                     self.ip_ranges[provider] = ranges
+                    self.network_regions[provider] = regions
                     self.last_updated[provider] = datetime.now(timezone.utc)
                     await self._store.set(
                         provider,
-                        {str(network) for network in ranges},
+                        _encode_cached(ranges, regions),
                         ttl=ttl,
                     )
             except Exception as e:
@@ -316,31 +380,24 @@ class CloudManager:
 
         for provider in providers:
             try:
-                cached = await self.redis_handler.get_key("cloud_ranges", provider)
+                cached = await self.redis_handler.get_key("cloud_ranges_v2", provider)
                 if cached:
-                    self.ip_ranges[provider] = {
-                        ipaddress.ip_network(ip) for ip in cached.split(",")
-                    }
+                    nets, regions = _decode_cached(set(cached.split(",")))
+                    self.ip_ranges[provider] = nets
+                    self.network_regions[provider] = regions
                     continue
 
-                fetch_func = {
-                    "AWS": fetch_aws_ip_ranges,
-                    "GCP": fetch_gcp_ip_ranges,
-                    "Azure": fetch_azure_ip_ranges,
-                    "DigitalOcean": fetch_digitalocean_ip_ranges,
-                    "Linode": fetch_linode_ip_ranges,
-                    "Vultr": fetch_vultr_ip_ranges,
-                }[provider]
-                ranges = await fetch_func()
+                ranges, regions = await _fetch_provider_ranges(provider)
                 if ranges:
                     old_ranges = self.ip_ranges.get(provider, set())
                     self._log_range_changes(provider, old_ranges, ranges)
                     self.ip_ranges[provider] = ranges
+                    self.network_regions[provider] = regions
                     self.last_updated[provider] = datetime.now(timezone.utc)
                     await self.redis_handler.set_key(
-                        "cloud_ranges",
+                        "cloud_ranges_v2",
                         provider,
-                        ",".join(str(ip) for ip in ranges),
+                        ",".join(sorted(_encode_cached(ranges, regions))),
                         ttl=ttl,
                     )
             except Exception as e:
@@ -351,11 +408,19 @@ class CloudManager:
     def is_cloud_ip(self, ip: str, providers: set[str] = _ALL_PROVIDERS) -> bool:
         try:
             ip_obj = ipaddress.ip_address(ip)
-            for provider in providers:
-                if provider in self.ip_ranges:
-                    for network in self.ip_ranges[provider]:
-                        if ip_obj in network:
-                            return True
+            blocked, carveouts = _parse_cloud_selectors(providers)
+            for provider in blocked:
+                if provider not in self.ip_ranges:
+                    continue
+                allowed_regions = carveouts.get(provider)
+                provider_regions = self.network_regions.get(provider, {})
+                for network in self.ip_ranges[provider]:
+                    if ip_obj in network:
+                        if allowed_regions and (
+                            provider_regions.get(str(network)) in allowed_regions
+                        ):
+                            continue
+                        return True
             return False
         except ValueError:
             self.logger.error(f"Invalid IP address: {ip}")

--- a/guard_core/handlers/cloud_ip_stores.py
+++ b/guard_core/handlers/cloud_ip_stores.py
@@ -27,7 +27,7 @@ class RedisCloudIpStore:
     def __init__(
         self,
         redis_handler: RedisHandlerProtocol,
-        key_prefix: str = "cloud_ip",
+        key_prefix: str = "cloud_ip_v2",
     ) -> None:
         self._redis = redis_handler
         self._prefix = key_prefix

--- a/guard_core/handlers/dynamic_rule_handler.py
+++ b/guard_core/handlers/dynamic_rule_handler.py
@@ -3,11 +3,10 @@ import logging
 import time
 from copy import deepcopy
 from datetime import datetime, timezone
-from typing import Any, cast
+from typing import Any
 
 from guard_core.models import (
     VALID_CLOUD_PROVIDERS,
-    CloudProvider,
     DynamicRules,
     SecurityConfig,
 )
@@ -283,8 +282,8 @@ class DynamicRuleManager:
             )
 
     async def _apply_cloud_provider_rules(self, providers: set[str]) -> None:
-        valid = {p for p in providers if p in VALID_CLOUD_PROVIDERS}
-        self.config.block_cloud_providers = cast(set[CloudProvider], valid)
+        valid = {p for p in providers if p.partition(":!")[0] in VALID_CLOUD_PROVIDERS}
+        self.config.block_cloud_providers = valid
         invalid = providers - valid
         if invalid:
             self.logger.warning(

--- a/guard_core/models.py
+++ b/guard_core/models.py
@@ -228,8 +228,13 @@ class SecurityConfig(BaseModel):
         default=600, description="Maximum age of CORS preflight results"
     )
 
-    block_cloud_providers: set[CloudProvider] | None = Field(
-        default=None, description="Set of cloud provider names to block"
+    block_cloud_providers: set[str] | None = Field(
+        default=None,
+        description=(
+            "Cloud providers to block. A bare provider ('GCP') blocks the whole "
+            "provider; a region carve-out ('GCP:!us-central1') blocks the provider "
+            "except that region. Region scoping is supported for GCP and AWS."
+        ),
     )
 
     cloud_ip_refresh_interval: int = Field(
@@ -602,7 +607,7 @@ class SecurityConfig(BaseModel):
     def validate_cloud_providers(cls, v: Any) -> set[str]:
         if v is None:
             return set()
-        return {p for p in v if p in VALID_CLOUD_PROVIDERS}
+        return {sel for sel in v if sel.partition(":!")[0] in VALID_CLOUD_PROVIDERS}
 
     @model_validator(mode="after")
     def validate_geo_ip_handler_exists(self) -> Self:

--- a/guard_core/sync/core/initialization/handler_initializer.py
+++ b/guard_core/sync/core/initialization/handler_initializer.py
@@ -127,7 +127,7 @@ class HandlerInitializer:
             try:
                 cloud_handler.initialize_redis(
                     self.redis_handler,
-                    cast(set[str], self.config.block_cloud_providers),
+                    self.config.block_cloud_providers,
                     ttl=self.config.cloud_ip_refresh_interval,
                 )
             except Exception as e:
@@ -175,7 +175,7 @@ class HandlerInitializer:
             if self.config.block_cloud_providers:
                 cloud_handler.initialize_redis(
                     self.redis_handler,
-                    cast(set[str], self.config.block_cloud_providers),
+                    self.config.block_cloud_providers,
                     ttl=self.config.cloud_ip_refresh_interval,
                 )
             if self.geo_ip_handler is not None:

--- a/guard_core/sync/decorators/access_control.py
+++ b/guard_core/sync/decorators/access_control.py
@@ -1,8 +1,8 @@
 import logging
 from collections.abc import Callable
-from typing import Any, cast
+from typing import Any
 
-from guard_core.models import VALID_CLOUD_PROVIDERS, CloudProvider
+from guard_core.models import VALID_CLOUD_PROVIDERS
 from guard_core.sync.decorators.base import BaseSecurityMixin, DecoratedFunction
 
 
@@ -48,12 +48,14 @@ class AccessControlMixin(BaseSecurityMixin):
         def decorator(func: Callable[..., Any]) -> DecoratedFunction:
             route_config = self._ensure_route_config(func)
             if providers is None:
-                route_config.block_cloud_providers = cast(
-                    set[CloudProvider], {"AWS", "GCP", "Azure"}
-                )
+                route_config.block_cloud_providers = {"AWS", "GCP", "Azure"}
             else:
-                valid = {p for p in providers if p in VALID_CLOUD_PROVIDERS}
-                route_config.block_cloud_providers = cast(set[CloudProvider], valid)
+                valid = {
+                    p
+                    for p in providers
+                    if p.partition(":!")[0] in VALID_CLOUD_PROVIDERS
+                }
+                route_config.block_cloud_providers = valid
                 invalid = set(providers) - valid
                 if invalid:
                     logging.getLogger("guard_core.sync.decorators").warning(

--- a/guard_core/sync/decorators/base.py
+++ b/guard_core/sync/decorators/base.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any, Protocol, cast, runtime_checkable
 
-from guard_core.models import CloudProvider, SecurityConfig
+from guard_core.models import SecurityConfig
 from guard_core.sync.handlers.behavior_handler import BehaviorRule, BehaviorTracker
 from guard_core.sync.protocols.request_protocol import SyncGuardRequest
 
@@ -29,7 +29,7 @@ class RouteConfig:
         self.blocked_user_agents: list[str] = []
         self.required_headers: dict[str, str] = {}
         self.behavior_rules: list[BehaviorRule] = []
-        self.block_cloud_providers: set[CloudProvider] = set()
+        self.block_cloud_providers: set[str] = set()
         self.max_request_size: int | None = None
         self.allowed_content_types: list[str] | None = None
         self.time_restrictions: dict[str, str] | None = None

--- a/guard_core/sync/handlers/cloud_handler.py
+++ b/guard_core/sync/handlers/cloud_handler.py
@@ -13,7 +13,9 @@ from guard_core.sync.protocols.cloud_ip_store_protocol import SyncCloudIpStorePr
 from guard_core.sync.protocols.redis_protocol import SyncRedisHandlerProtocol
 
 
-def fetch_aws_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+def fetch_aws_ip_ranges() -> tuple[
+    set[ipaddress.IPv4Network | ipaddress.IPv6Network], dict[str, str]
+]:
     try:
         with requests.Session() as session:
             response = session.get(
@@ -22,17 +24,25 @@ def fetch_aws_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6Network]:
             )
             response.raise_for_status()
             data = response.json()
-        return {
-            ipaddress.ip_network(ip_range["ip_prefix"])
-            for ip_range in data["prefixes"]
-            if ip_range["service"] == "AMAZON"
-        }
+        networks: set[ipaddress.IPv4Network | ipaddress.IPv6Network] = set()
+        regions: dict[str, str] = {}
+        for ip_range in data["prefixes"]:
+            if ip_range["service"] != "AMAZON":
+                continue
+            network = ipaddress.ip_network(ip_range["ip_prefix"])
+            networks.add(network)
+            region = ip_range.get("region")
+            if region:
+                regions[str(network)] = region
+        return networks, regions
     except Exception as e:
         logging.error(f"Failed to fetch AWS IP ranges: {str(e)}")
-        return set()
+        return set(), {}
 
 
-def fetch_gcp_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+def fetch_gcp_ip_ranges() -> tuple[
+    set[ipaddress.IPv4Network | ipaddress.IPv6Network], dict[str, str]
+]:
     try:
         with requests.Session() as session:
             response = session.get(
@@ -42,15 +52,20 @@ def fetch_gcp_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6Network]:
             response.raise_for_status()
             data = response.json()
         networks: set[ipaddress.IPv4Network | ipaddress.IPv6Network] = set()
+        regions: dict[str, str] = {}
         for ip_range in data["prefixes"]:
-            if "ipv4Prefix" in ip_range:
-                networks.add(ipaddress.ip_network(ip_range["ipv4Prefix"]))
-            elif "ipv6Prefix" in ip_range:
-                networks.add(ipaddress.ip_network(ip_range["ipv6Prefix"]))
-        return networks
+            prefix = ip_range.get("ipv4Prefix") or ip_range.get("ipv6Prefix")
+            if not prefix:
+                continue
+            network = ipaddress.ip_network(prefix)
+            networks.add(network)
+            scope = ip_range.get("scope")
+            if scope:
+                regions[str(network)] = scope
+        return networks, regions
     except Exception as e:
         logging.error(f"Failed to fetch GCP IP ranges: {str(e)}")
-        return set()
+        return set(), {}
 
 
 def fetch_azure_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6Network]:
@@ -178,9 +193,66 @@ def fetch_vultr_ip_ranges() -> set[ipaddress.IPv4Network | ipaddress.IPv6Network
 _ALL_PROVIDERS = set({"AWS", "GCP", "Azure", "DigitalOcean", "Linode", "Vultr"})
 
 
+def _parse_cloud_selectors(
+    selectors: set[str],
+) -> tuple[set[str], dict[str, set[str]]]:
+    blocked: set[str] = set()
+    carveouts: dict[str, set[str]] = {}
+    for selector in selectors:
+        provider, marker, region = selector.partition(":!")
+        blocked.add(provider)
+        if marker and region:
+            carveouts.setdefault(provider, set()).add(region)
+    return blocked, carveouts
+
+
+def _fetch_provider_ranges(
+    provider: str,
+) -> tuple[set[ipaddress.IPv4Network | ipaddress.IPv6Network], dict[str, str]]:
+    fetchers = {
+        "AWS": fetch_aws_ip_ranges,
+        "GCP": fetch_gcp_ip_ranges,
+        "Azure": fetch_azure_ip_ranges,
+        "DigitalOcean": fetch_digitalocean_ip_ranges,
+        "Linode": fetch_linode_ip_ranges,
+        "Vultr": fetch_vultr_ip_ranges,
+    }
+    result: Any = fetchers[provider]()
+    if isinstance(result, tuple):
+        return result
+    return result, {}
+
+
+def _encode_cached(
+    ranges: set[ipaddress.IPv4Network | ipaddress.IPv6Network],
+    regions: dict[str, str],
+) -> set[str]:
+    encoded: set[str] = set()
+    for network in ranges:
+        key = str(network)
+        region = regions.get(key)
+        encoded.add(f"{key}|{region}" if region else key)
+    return encoded
+
+
+def _decode_cached(
+    entries: set[str],
+) -> tuple[set[ipaddress.IPv4Network | ipaddress.IPv6Network], dict[str, str]]:
+    networks: set[ipaddress.IPv4Network | ipaddress.IPv6Network] = set()
+    regions: dict[str, str] = {}
+    for entry in entries:
+        prefix, separator, region = entry.partition("|")
+        network = ipaddress.ip_network(prefix)
+        networks.add(network)
+        if separator and region:
+            regions[str(network)] = region
+    return networks, regions
+
+
 class CloudManager:
     _instance = None
     ip_ranges: dict[str, set[ipaddress.IPv4Network | ipaddress.IPv6Network]]
+    network_regions: dict[str, dict[str, str]]
     redis_handler: SyncRedisHandlerProtocol | None = None
     agent_handler: SyncAgentHandlerProtocol | None = None
     logger: logging.Logger
@@ -197,6 +269,9 @@ class CloudManager:
                 "DigitalOcean": set(),
                 "Linode": set(),
                 "Vultr": set(),
+            }
+            cls._instance.network_regions = {
+                provider: {} for provider in _ALL_PROVIDERS
             }
             cls._instance.last_updated = {provider: None for provider in _ALL_PROVIDERS}
             cls._instance.redis_handler = None
@@ -226,22 +301,17 @@ class CloudManager:
     def _refresh_providers(self, providers: set[str] = _ALL_PROVIDERS) -> None:
         for provider in providers:
             try:
-                ranges = {
-                    "AWS": fetch_aws_ip_ranges,
-                    "GCP": fetch_gcp_ip_ranges,
-                    "Azure": fetch_azure_ip_ranges,
-                    "DigitalOcean": fetch_digitalocean_ip_ranges,
-                    "Linode": fetch_linode_ip_ranges,
-                    "Vultr": fetch_vultr_ip_ranges,
-                }[provider]()
+                ranges, regions = _fetch_provider_ranges(provider)
                 if ranges:
                     old_ranges = self.ip_ranges.get(provider, set())
                     self._log_range_changes(provider, old_ranges, ranges)
                     self.ip_ranges[provider] = ranges
+                    self.network_regions[provider] = regions
                     self.last_updated[provider] = datetime.now(timezone.utc)
             except Exception as e:
                 self.logger.error(f"Failed to fetch {provider} IP ranges: {str(e)}")
                 self.ip_ranges[provider] = set()
+                self.network_regions[provider] = {}
 
     def initialize_redis(
         self,
@@ -275,27 +345,21 @@ class CloudManager:
             try:
                 cached = self._store.get(provider)
                 if cached is not None:
-                    self.ip_ranges[provider] = {ipaddress.ip_network(s) for s in cached}
+                    nets, regions = _decode_cached(cached)
+                    self.ip_ranges[provider] = nets
+                    self.network_regions[provider] = regions
                     continue
 
-                fetch_func = {
-                    "AWS": fetch_aws_ip_ranges,
-                    "GCP": fetch_gcp_ip_ranges,
-                    "Azure": fetch_azure_ip_ranges,
-                    "DigitalOcean": fetch_digitalocean_ip_ranges,
-                    "Linode": fetch_linode_ip_ranges,
-                    "Vultr": fetch_vultr_ip_ranges,
-                }[provider]
-
-                ranges = fetch_func()
+                ranges, regions = _fetch_provider_ranges(provider)
                 if ranges:
                     old_ranges = self.ip_ranges.get(provider, set())
                     self._log_range_changes(provider, old_ranges, ranges)
                     self.ip_ranges[provider] = ranges
+                    self.network_regions[provider] = regions
                     self.last_updated[provider] = datetime.now(timezone.utc)
                     self._store.set(
                         provider,
-                        {str(network) for network in ranges},
+                        _encode_cached(ranges, regions),
                         ttl=ttl,
                     )
             except Exception as e:
@@ -312,31 +376,24 @@ class CloudManager:
 
         for provider in providers:
             try:
-                cached = self.redis_handler.get_key("cloud_ranges", provider)
+                cached = self.redis_handler.get_key("cloud_ranges_v2", provider)
                 if cached:
-                    self.ip_ranges[provider] = {
-                        ipaddress.ip_network(ip) for ip in cached.split(",")
-                    }
+                    nets, regions = _decode_cached(set(cached.split(",")))
+                    self.ip_ranges[provider] = nets
+                    self.network_regions[provider] = regions
                     continue
 
-                fetch_func = {
-                    "AWS": fetch_aws_ip_ranges,
-                    "GCP": fetch_gcp_ip_ranges,
-                    "Azure": fetch_azure_ip_ranges,
-                    "DigitalOcean": fetch_digitalocean_ip_ranges,
-                    "Linode": fetch_linode_ip_ranges,
-                    "Vultr": fetch_vultr_ip_ranges,
-                }[provider]
-                ranges = fetch_func()
+                ranges, regions = _fetch_provider_ranges(provider)
                 if ranges:
                     old_ranges = self.ip_ranges.get(provider, set())
                     self._log_range_changes(provider, old_ranges, ranges)
                     self.ip_ranges[provider] = ranges
+                    self.network_regions[provider] = regions
                     self.last_updated[provider] = datetime.now(timezone.utc)
                     self.redis_handler.set_key(
-                        "cloud_ranges",
+                        "cloud_ranges_v2",
                         provider,
-                        ",".join(str(ip) for ip in ranges),
+                        ",".join(sorted(_encode_cached(ranges, regions))),
                         ttl=ttl,
                     )
             except Exception as e:
@@ -347,11 +404,19 @@ class CloudManager:
     def is_cloud_ip(self, ip: str, providers: set[str] = _ALL_PROVIDERS) -> bool:
         try:
             ip_obj = ipaddress.ip_address(ip)
-            for provider in providers:
-                if provider in self.ip_ranges:
-                    for network in self.ip_ranges[provider]:
-                        if ip_obj in network:
-                            return True
+            blocked, carveouts = _parse_cloud_selectors(providers)
+            for provider in blocked:
+                if provider not in self.ip_ranges:
+                    continue
+                allowed_regions = carveouts.get(provider)
+                provider_regions = self.network_regions.get(provider, {})
+                for network in self.ip_ranges[provider]:
+                    if ip_obj in network:
+                        if allowed_regions and (
+                            provider_regions.get(str(network)) in allowed_regions
+                        ):
+                            continue
+                        return True
             return False
         except ValueError:
             self.logger.error(f"Invalid IP address: {ip}")

--- a/guard_core/sync/handlers/cloud_ip_stores.py
+++ b/guard_core/sync/handlers/cloud_ip_stores.py
@@ -25,7 +25,7 @@ class RedisCloudIpStore:
     def __init__(
         self,
         redis_handler: SyncRedisHandlerProtocol,
-        key_prefix: str = "cloud_ip",
+        key_prefix: str = "cloud_ip_v2",
     ) -> None:
         self._redis = redis_handler
         self._prefix = key_prefix

--- a/guard_core/sync/handlers/dynamic_rule_handler.py
+++ b/guard_core/sync/handlers/dynamic_rule_handler.py
@@ -3,11 +3,10 @@ import threading
 import time
 from copy import deepcopy
 from datetime import datetime, timezone
-from typing import Any, cast
+from typing import Any
 
 from guard_core.models import (
     VALID_CLOUD_PROVIDERS,
-    CloudProvider,
     DynamicRules,
     SecurityConfig,
 )
@@ -283,8 +282,8 @@ class DynamicRuleManager:
             )
 
     def _apply_cloud_provider_rules(self, providers: set[str]) -> None:
-        valid = {p for p in providers if p in VALID_CLOUD_PROVIDERS}
-        self.config.block_cloud_providers = cast(set[CloudProvider], valid)
+        valid = {p for p in providers if p.partition(":!")[0] in VALID_CLOUD_PROVIDERS}
+        self.config.block_cloud_providers = valid
         invalid = providers - valid
         if invalid:
             self.logger.warning(

--- a/tests/test_cloud_ip_stores.py
+++ b/tests/test_cloud_ip_stores.py
@@ -314,7 +314,7 @@ async def test_cloud_manager_legacy_redis_handler_writes_back_after_fetch(
     assert ipaddress.ip_network("198.51.100.0/24") in mgr.ip_ranges["AWS"]
     redis_handler.set_key.assert_awaited_once()
     call = redis_handler.set_key.call_args
-    assert call.args[0] == "cloud_ranges"
+    assert call.args[0] == "cloud_ranges_v2"
     assert call.args[1] == "AWS"
     assert call.kwargs["ttl"] == 900
 
@@ -359,7 +359,7 @@ async def test_cloud_manager_legacy_redis_path_skips_write_when_fetch_returns_em
 def test_redis_cloud_ip_store_default_key_prefix_is_unprefixed() -> None:
     redis_handler = AsyncMock()
     store = RedisCloudIpStore(redis_handler)
-    assert store._prefix == "cloud_ip"
+    assert store._prefix == "cloud_ip_v2"
 
 
 async def test_redis_cloud_ip_store_set_uses_unprefixed_namespace() -> None:
@@ -369,7 +369,7 @@ async def test_redis_cloud_ip_store_set_uses_unprefixed_namespace() -> None:
 
     redis_handler.set_key.assert_awaited_once()
     call_args = redis_handler.set_key.await_args
-    assert call_args.args[0] == "cloud_ip"
+    assert call_args.args[0] == "cloud_ip_v2"
     assert call_args.args[1] == "AWS"
 
 

--- a/tests/test_cloud_ips/test_cloud_ips.py
+++ b/tests/test_cloud_ips/test_cloud_ips.py
@@ -58,33 +58,39 @@ async def test_fetch_aws_ip_ranges(mock_aiohttp_session: MagicMock) -> None:
     mock_resp = _mock_aiohttp_response(
         json_data={
             "prefixes": [
-                {"ip_prefix": "192.168.0.0/24", "service": "AMAZON"},
+                {
+                    "ip_prefix": "192.168.0.0/24",
+                    "service": "AMAZON",
+                    "region": "us-east-1",
+                },
                 {"ip_prefix": "10.0.0.0/8", "service": "EC2"},
             ]
         }
     )
     mock_aiohttp_session.get = AsyncMock(return_value=mock_resp)
 
-    result = await fetch_aws_ip_ranges()
-    assert ipaddress.IPv4Network("192.168.0.0/24") in result
-    assert ipaddress.IPv4Network("10.0.0.0/8") not in result
+    networks, regions = await fetch_aws_ip_ranges()
+    assert ipaddress.IPv4Network("192.168.0.0/24") in networks
+    assert ipaddress.IPv4Network("10.0.0.0/8") not in networks
+    assert regions[str(ipaddress.IPv4Network("192.168.0.0/24"))] == "us-east-1"
 
 
 async def test_fetch_gcp_ip_ranges(mock_aiohttp_session: MagicMock) -> None:
     mock_resp = _mock_aiohttp_response(
         json_data={
             "prefixes": [
-                {"ipv4Prefix": "172.16.0.0/12"},
-                {"ipv6Prefix": "2001:db8::/32"},
+                {"ipv4Prefix": "172.16.0.0/12", "scope": "us-central1"},
+                {"ipv6Prefix": "2001:db8::/32", "scope": "europe-west1"},
             ]
         }
     )
     mock_aiohttp_session.get = AsyncMock(return_value=mock_resp)
 
-    result = await fetch_gcp_ip_ranges()
-    assert ipaddress.IPv4Network("172.16.0.0/12") in result
-    assert ipaddress.IPv6Network("2001:db8::/32") in result
-    assert len(result) == 2
+    networks, regions = await fetch_gcp_ip_ranges()
+    assert ipaddress.IPv4Network("172.16.0.0/12") in networks
+    assert ipaddress.IPv6Network("2001:db8::/32") in networks
+    assert len(networks) == 2
+    assert regions[str(ipaddress.IPv4Network("172.16.0.0/12"))] == "us-central1"
 
 
 async def test_fetch_azure_ip_ranges(mock_aiohttp_session: MagicMock) -> None:
@@ -265,16 +271,16 @@ def test_cloud_ip_ranges_invalid_ip() -> None:
 
 async def test_fetch_aws_ip_ranges_error(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.get = AsyncMock(side_effect=Exception("API failure"))
-    result = await fetch_aws_ip_ranges()
-    assert result == set()
+    networks, _ = await fetch_aws_ip_ranges()
+    assert networks == set()
 
 
 async def test_fetch_gcp_ip_ranges_error(mock_aiohttp_session: MagicMock) -> None:
     mock_resp = _mock_aiohttp_response()
     mock_resp.json = AsyncMock(side_effect=Exception("Invalid JSON"))
     mock_aiohttp_session.get = AsyncMock(return_value=mock_resp)
-    result = await fetch_gcp_ip_ranges()
-    assert result == set()
+    networks, _ = await fetch_gcp_ip_ranges()
+    assert networks == set()
 
 
 async def test_cloud_manager_refresh_handling() -> None:
@@ -389,13 +395,13 @@ async def test_cloud_ip_redis_caching(security_config_redis: SecurityConfig) -> 
         assert cloud_handler.is_cloud_ip("192.168.0.1", {"AWS"})
         import json as _json
 
-        cached_raw = await redis_handler.get_key("cloud_ip", "AWS")
+        cached_raw = await redis_handler.get_key("cloud_ip_v2", "AWS")
         assert _json.loads(cached_raw) == ["192.168.0.0/24"]
 
         mock_aws.return_value = {ipaddress.IPv4Network("192.168.1.0/24")}
         await cloud_handler.refresh_async()
 
-        await redis_handler.delete("cloud_ip", "AWS")
+        await redis_handler.delete("cloud_ip_v2", "AWS")
         await cloud_handler.refresh_async()
 
         mock_aws.side_effect = Exception("API Error")
@@ -417,7 +423,7 @@ async def test_cloud_ip_redis_cache_hit(
     redis_handler = RedisManager(security_config_redis)
     await redis_handler.initialize()
 
-    await redis_handler.set_key("cloud_ip", "AWS", _json.dumps(["192.168.0.0/24"]))
+    await redis_handler.set_key("cloud_ip_v2", "AWS", _json.dumps(["192.168.0.0/24"]))
 
     await cloud_handler.initialize_redis(redis_handler)
 
@@ -495,8 +501,8 @@ async def test_cloud_ip_redis_error_handling(
         redis_handler = RedisManager(security_config_redis)
         await redis_handler.initialize()
 
-        await redis_handler.delete("cloud_ranges", "AWS")
-        await redis_handler.delete("cloud_ip", "AWS")
+        await redis_handler.delete("cloud_ranges_v2", "AWS")
+        await redis_handler.delete("cloud_ip_v2", "AWS")
 
         mock_aws.side_effect = Exception("API Error")
         await cloud_handler.initialize_redis(redis_handler)
@@ -924,9 +930,9 @@ async def test_fetch_gcp_ip_ranges_skips_unknown_prefix_keys(
         }
     )
     mock_aiohttp_session.get = AsyncMock(return_value=mock_resp)
-    result = await fetch_gcp_ip_ranges()
-    assert ipaddress.IPv4Network("172.16.0.0/12") in result
-    assert len(result) == 1
+    networks, _ = await fetch_gcp_ip_ranges()
+    assert ipaddress.IPv4Network("172.16.0.0/12") in networks
+    assert len(networks) == 1
 
 
 async def test_initialize_redis_replaces_in_memory_store(

--- a/tests/test_cloud_region_scope.py
+++ b/tests/test_cloud_region_scope.py
@@ -1,0 +1,145 @@
+import ipaddress
+from collections.abc import Generator
+
+import pytest
+
+from guard_core.handlers.cloud_handler import (
+    CloudManager,
+    _decode_cached,
+    _encode_cached,
+    _parse_cloud_selectors,
+)
+from guard_core.models import SecurityConfig
+
+
+def test_security_config_keeps_region_selector() -> None:
+    config = SecurityConfig(block_cloud_providers={"GCP:!us-central1"})
+    assert config.block_cloud_providers == {"GCP:!us-central1"}
+
+
+def test_security_config_keeps_bare_provider() -> None:
+    config = SecurityConfig(block_cloud_providers={"GCP"})
+    assert config.block_cloud_providers == {"GCP"}
+
+
+def test_security_config_drops_unknown_provider_selector() -> None:
+    config = SecurityConfig(block_cloud_providers={"Bogus:!x", "GCP"})
+    assert config.block_cloud_providers == {"GCP"}
+
+
+def test_parse_selectors_bare_provider() -> None:
+    blocked, carveouts = _parse_cloud_selectors({"GCP"})
+    assert blocked == {"GCP"}
+    assert carveouts == {}
+
+
+def test_parse_selectors_carveout() -> None:
+    blocked, carveouts = _parse_cloud_selectors({"GCP:!us-central1"})
+    assert blocked == {"GCP"}
+    assert carveouts == {"GCP": {"us-central1"}}
+
+
+def test_parse_selectors_mixed_providers_and_carveouts() -> None:
+    blocked, carveouts = _parse_cloud_selectors(
+        {"GCP", "GCP:!us-central1", "AWS:!us-east-1"}
+    )
+    assert blocked == {"GCP", "AWS"}
+    assert carveouts == {"GCP": {"us-central1"}, "AWS": {"us-east-1"}}
+
+
+def test_parse_selectors_carveout_implies_provider_block() -> None:
+    blocked, carveouts = _parse_cloud_selectors({"AWS:!us-east-1"})
+    assert blocked == {"AWS"}
+    assert carveouts == {"AWS": {"us-east-1"}}
+
+
+@pytest.fixture
+def gcp_regions() -> Generator[tuple[CloudManager, str, str], None, None]:
+    manager = CloudManager()
+    saved_ranges = dict(manager.ip_ranges)
+    saved_regions = dict(manager.network_regions)
+    net_central = ipaddress.ip_network("34.100.0.0/24")
+    net_europe = ipaddress.ip_network("35.200.0.0/24")
+    manager.ip_ranges["GCP"] = {net_central, net_europe}
+    manager.network_regions["GCP"] = {
+        str(net_central): "us-central1",
+        str(net_europe): "europe-west1",
+    }
+    yield manager, "34.100.0.5", "35.200.0.5"
+    manager.ip_ranges = saved_ranges
+    manager.network_regions = saved_regions
+
+
+def test_block_whole_provider_unchanged(
+    gcp_regions: tuple[CloudManager, str, str],
+) -> None:
+    manager, central_ip, europe_ip = gcp_regions
+    assert manager.is_cloud_ip(central_ip, {"GCP"}) is True
+    assert manager.is_cloud_ip(europe_ip, {"GCP"}) is True
+
+
+def test_carveout_allows_excepted_region(
+    gcp_regions: tuple[CloudManager, str, str],
+) -> None:
+    manager, central_ip, europe_ip = gcp_regions
+    assert manager.is_cloud_ip(central_ip, {"GCP:!us-central1"}) is False
+    assert manager.is_cloud_ip(europe_ip, {"GCP:!us-central1"}) is True
+
+
+def test_carveout_other_region_still_blocked(
+    gcp_regions: tuple[CloudManager, str, str],
+) -> None:
+    manager, central_ip, _ = gcp_regions
+    assert manager.is_cloud_ip(central_ip, {"GCP:!europe-west1"}) is True
+
+
+def test_non_cloud_ip_not_blocked(
+    gcp_regions: tuple[CloudManager, str, str],
+) -> None:
+    manager, _, _ = gcp_regions
+    assert manager.is_cloud_ip("8.8.8.8", {"GCP"}) is False
+    assert manager.is_cloud_ip("8.8.8.8", {"GCP:!us-central1"}) is False
+
+
+def test_cache_encode_decode_roundtrip_preserves_region() -> None:
+    net_a = ipaddress.ip_network("34.100.0.0/24")
+    net_b = ipaddress.ip_network("8.8.8.0/24")
+    ranges = {net_a, net_b}
+    regions = {str(net_a): "us-central1"}
+
+    encoded = _encode_cached(ranges, regions)
+    nets, decoded_regions = _decode_cached(encoded)
+
+    assert nets == ranges
+    assert decoded_regions == {str(net_a): "us-central1"}
+
+
+def test_decode_tolerates_legacy_unscoped_entries() -> None:
+    net = ipaddress.ip_network("34.100.0.0/24")
+    nets, regions = _decode_cached({str(net)})
+    assert nets == {net}
+    assert regions == {}
+
+
+async def test_refresh_populates_network_regions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    net = ipaddress.ip_network("34.100.0.0/24")
+
+    async def fake_gcp() -> tuple[set[ipaddress.IPv4Network], dict[str, str]]:
+        return {net}, {str(net): "us-central1"}
+
+    monkeypatch.setattr(
+        "guard_core.handlers.cloud_handler.fetch_gcp_ip_ranges", fake_gcp
+    )
+    manager = CloudManager()
+    saved_ranges = dict(manager.ip_ranges)
+    saved_regions = dict(manager.network_regions)
+
+    await manager._refresh_providers({"GCP"})
+
+    assert manager.network_regions["GCP"] == {str(net): "us-central1"}
+    assert manager.is_cloud_ip("34.100.0.5", {"GCP:!us-central1"}) is False
+
+    manager.ip_ranges = saved_ranges
+    manager.network_regions = saved_regions

--- a/tests/test_handler_edge_cases.py
+++ b/tests/test_handler_edge_cases.py
@@ -504,9 +504,9 @@ async def test_fetch_gcp_ignores_prefixes_lacking_both_ipv4_and_ipv6() -> None:
             return response
 
     with patch("guard_core.handlers.cloud_handler.aiohttp.ClientSession", _FakeSession):
-        result = await fetch_gcp_ip_ranges()
+        networks, _ = await fetch_gcp_ip_ranges()
 
-    assert len(result) == 1
+    assert len(networks) == 1
 
 
 async def test_ipban_reset_noop_when_no_redis_handler() -> None:

--- a/tests/test_sync/test_cloud_ip_stores.py
+++ b/tests/test_sync/test_cloud_ip_stores.py
@@ -316,7 +316,7 @@ def test_cloud_manager_legacy_redis_handler_writes_back_after_fetch(
     assert ipaddress.ip_network("198.51.100.0/24") in mgr.ip_ranges["AWS"]
     redis_handler.set_key.assert_called_once()
     call = redis_handler.set_key.call_args
-    assert call.args[0] == "cloud_ranges"
+    assert call.args[0] == "cloud_ranges_v2"
     assert call.args[1] == "AWS"
     assert call.kwargs["ttl"] == 900
 
@@ -365,7 +365,7 @@ def test_cloud_manager_legacy_redis_path_skips_write_when_fetch_returns_empty(
 def test_redis_cloud_ip_store_default_key_prefix_is_unprefixed() -> None:
     redis_handler = MagicMock()
     store = RedisCloudIpStore(redis_handler)
-    assert store._prefix == "cloud_ip"
+    assert store._prefix == "cloud_ip_v2"
 
 
 def test_redis_cloud_ip_store_set_uses_unprefixed_namespace() -> None:
@@ -375,7 +375,7 @@ def test_redis_cloud_ip_store_set_uses_unprefixed_namespace() -> None:
 
     redis_handler.set_key.assert_called_once()
     call_args = redis_handler.set_key.call_args
-    assert call_args.args[0] == "cloud_ip"
+    assert call_args.args[0] == "cloud_ip_v2"
     assert call_args.args[1] == "AWS"
 
 

--- a/tests/test_sync/test_cloud_ips/test_cloud_ips.py
+++ b/tests/test_sync/test_cloud_ips/test_cloud_ips.py
@@ -58,33 +58,39 @@ def test_fetch_aws_ip_ranges(mock_aiohttp_session: MagicMock) -> None:
     mock_resp = _mock_aiohttp_response(
         json_data={
             "prefixes": [
-                {"ip_prefix": "192.168.0.0/24", "service": "AMAZON"},
+                {
+                    "ip_prefix": "192.168.0.0/24",
+                    "service": "AMAZON",
+                    "region": "us-east-1",
+                },
                 {"ip_prefix": "10.0.0.0/8", "service": "EC2"},
             ]
         }
     )
     mock_aiohttp_session.get = MagicMock(return_value=mock_resp)
 
-    result = fetch_aws_ip_ranges()
-    assert ipaddress.IPv4Network("192.168.0.0/24") in result
-    assert ipaddress.IPv4Network("10.0.0.0/8") not in result
+    networks, regions = fetch_aws_ip_ranges()
+    assert ipaddress.IPv4Network("192.168.0.0/24") in networks
+    assert ipaddress.IPv4Network("10.0.0.0/8") not in networks
+    assert regions[str(ipaddress.IPv4Network("192.168.0.0/24"))] == "us-east-1"
 
 
 def test_fetch_gcp_ip_ranges(mock_aiohttp_session: MagicMock) -> None:
     mock_resp = _mock_aiohttp_response(
         json_data={
             "prefixes": [
-                {"ipv4Prefix": "172.16.0.0/12"},
-                {"ipv6Prefix": "2001:db8::/32"},
+                {"ipv4Prefix": "172.16.0.0/12", "scope": "us-central1"},
+                {"ipv6Prefix": "2001:db8::/32", "scope": "europe-west1"},
             ]
         }
     )
     mock_aiohttp_session.get = MagicMock(return_value=mock_resp)
 
-    result = fetch_gcp_ip_ranges()
-    assert ipaddress.IPv4Network("172.16.0.0/12") in result
-    assert ipaddress.IPv6Network("2001:db8::/32") in result
-    assert len(result) == 2
+    networks, regions = fetch_gcp_ip_ranges()
+    assert ipaddress.IPv4Network("172.16.0.0/12") in networks
+    assert ipaddress.IPv6Network("2001:db8::/32") in networks
+    assert len(networks) == 2
+    assert regions[str(ipaddress.IPv4Network("172.16.0.0/12"))] == "us-central1"
 
 
 def test_fetch_azure_ip_ranges(mock_aiohttp_session: MagicMock) -> None:
@@ -247,16 +253,16 @@ def test_cloud_ip_ranges_invalid_ip() -> None:
 
 def test_fetch_aws_ip_ranges_error(mock_aiohttp_session: MagicMock) -> None:
     mock_aiohttp_session.get = MagicMock(side_effect=Exception("API failure"))
-    result = fetch_aws_ip_ranges()
-    assert result == set()
+    networks, _ = fetch_aws_ip_ranges()
+    assert networks == set()
 
 
 def test_fetch_gcp_ip_ranges_error(mock_aiohttp_session: MagicMock) -> None:
     mock_resp = _mock_aiohttp_response()
     mock_resp.json = MagicMock(side_effect=Exception("Invalid JSON"))
     mock_aiohttp_session.get = MagicMock(return_value=mock_resp)
-    result = fetch_gcp_ip_ranges()
-    assert result == set()
+    networks, _ = fetch_gcp_ip_ranges()
+    assert networks == set()
 
 
 def test_cloud_manager_refresh_handling() -> None:
@@ -359,13 +365,13 @@ def test_cloud_ip_redis_caching(security_config_redis: SecurityConfig) -> None:
         assert cloud_handler.is_cloud_ip("192.168.0.1", {"AWS"})
         import json as _json
 
-        cached_raw = redis_handler.get_key("cloud_ip", "AWS")
+        cached_raw = redis_handler.get_key("cloud_ip_v2", "AWS")
         assert _json.loads(cached_raw) == ["192.168.0.0/24"]
 
         mock_aws.return_value = {ipaddress.IPv4Network("192.168.1.0/24")}
         cloud_handler.refresh_async()
 
-        redis_handler.delete("cloud_ip", "AWS")
+        redis_handler.delete("cloud_ip_v2", "AWS")
         cloud_handler.refresh_async()
 
         mock_aws.side_effect = Exception("API Error")
@@ -387,7 +393,7 @@ def test_cloud_ip_redis_cache_hit(
     redis_handler = RedisManager(security_config_redis)
     redis_handler.initialize()
 
-    redis_handler.set_key("cloud_ip", "AWS", _json.dumps(["192.168.0.0/24"]))
+    redis_handler.set_key("cloud_ip_v2", "AWS", _json.dumps(["192.168.0.0/24"]))
 
     cloud_handler.initialize_redis(redis_handler)
 
@@ -457,8 +463,8 @@ def test_cloud_ip_redis_error_handling(
         redis_handler = RedisManager(security_config_redis)
         redis_handler.initialize()
 
-        redis_handler.delete("cloud_ranges", "AWS")
-        redis_handler.delete("cloud_ip", "AWS")
+        redis_handler.delete("cloud_ranges_v2", "AWS")
+        redis_handler.delete("cloud_ip_v2", "AWS")
 
         mock_aws.side_effect = Exception("API Error")
         cloud_handler.initialize_redis(redis_handler)
@@ -862,9 +868,9 @@ def test_fetch_gcp_ip_ranges_skips_unknown_prefix_keys(
         }
     )
     mock_aiohttp_session.get = MagicMock(return_value=mock_resp)
-    result = fetch_gcp_ip_ranges()
-    assert ipaddress.IPv4Network("172.16.0.0/12") in result
-    assert len(result) == 1
+    networks, _ = fetch_gcp_ip_ranges()
+    assert ipaddress.IPv4Network("172.16.0.0/12") in networks
+    assert len(networks) == 1
 
 
 def test_initialize_redis_replaces_in_memory_store(

--- a/tests/test_sync/test_cloud_region_scope.py
+++ b/tests/test_sync/test_cloud_region_scope.py
@@ -1,0 +1,145 @@
+import ipaddress
+from collections.abc import Generator
+
+import pytest
+
+from guard_core.models import SecurityConfig
+from guard_core.sync.handlers.cloud_handler import (
+    CloudManager,
+    _decode_cached,
+    _encode_cached,
+    _parse_cloud_selectors,
+)
+
+
+def test_security_config_keeps_region_selector() -> None:
+    config = SecurityConfig(block_cloud_providers={"GCP:!us-central1"})
+    assert config.block_cloud_providers == {"GCP:!us-central1"}
+
+
+def test_security_config_keeps_bare_provider() -> None:
+    config = SecurityConfig(block_cloud_providers={"GCP"})
+    assert config.block_cloud_providers == {"GCP"}
+
+
+def test_security_config_drops_unknown_provider_selector() -> None:
+    config = SecurityConfig(block_cloud_providers={"Bogus:!x", "GCP"})
+    assert config.block_cloud_providers == {"GCP"}
+
+
+def test_parse_selectors_bare_provider() -> None:
+    blocked, carveouts = _parse_cloud_selectors({"GCP"})
+    assert blocked == {"GCP"}
+    assert carveouts == {}
+
+
+def test_parse_selectors_carveout() -> None:
+    blocked, carveouts = _parse_cloud_selectors({"GCP:!us-central1"})
+    assert blocked == {"GCP"}
+    assert carveouts == {"GCP": {"us-central1"}}
+
+
+def test_parse_selectors_mixed_providers_and_carveouts() -> None:
+    blocked, carveouts = _parse_cloud_selectors(
+        {"GCP", "GCP:!us-central1", "AWS:!us-east-1"}
+    )
+    assert blocked == {"GCP", "AWS"}
+    assert carveouts == {"GCP": {"us-central1"}, "AWS": {"us-east-1"}}
+
+
+def test_parse_selectors_carveout_implies_provider_block() -> None:
+    blocked, carveouts = _parse_cloud_selectors({"AWS:!us-east-1"})
+    assert blocked == {"AWS"}
+    assert carveouts == {"AWS": {"us-east-1"}}
+
+
+@pytest.fixture
+def gcp_regions() -> Generator[tuple[CloudManager, str, str], None, None]:
+    manager = CloudManager()
+    saved_ranges = dict(manager.ip_ranges)
+    saved_regions = dict(manager.network_regions)
+    net_central = ipaddress.ip_network("34.100.0.0/24")
+    net_europe = ipaddress.ip_network("35.200.0.0/24")
+    manager.ip_ranges["GCP"] = {net_central, net_europe}
+    manager.network_regions["GCP"] = {
+        str(net_central): "us-central1",
+        str(net_europe): "europe-west1",
+    }
+    yield manager, "34.100.0.5", "35.200.0.5"
+    manager.ip_ranges = saved_ranges
+    manager.network_regions = saved_regions
+
+
+def test_block_whole_provider_unchanged(
+    gcp_regions: tuple[CloudManager, str, str],
+) -> None:
+    manager, central_ip, europe_ip = gcp_regions
+    assert manager.is_cloud_ip(central_ip, {"GCP"}) is True
+    assert manager.is_cloud_ip(europe_ip, {"GCP"}) is True
+
+
+def test_carveout_allows_excepted_region(
+    gcp_regions: tuple[CloudManager, str, str],
+) -> None:
+    manager, central_ip, europe_ip = gcp_regions
+    assert manager.is_cloud_ip(central_ip, {"GCP:!us-central1"}) is False
+    assert manager.is_cloud_ip(europe_ip, {"GCP:!us-central1"}) is True
+
+
+def test_carveout_other_region_still_blocked(
+    gcp_regions: tuple[CloudManager, str, str],
+) -> None:
+    manager, central_ip, _ = gcp_regions
+    assert manager.is_cloud_ip(central_ip, {"GCP:!europe-west1"}) is True
+
+
+def test_non_cloud_ip_not_blocked(
+    gcp_regions: tuple[CloudManager, str, str],
+) -> None:
+    manager, _, _ = gcp_regions
+    assert manager.is_cloud_ip("8.8.8.8", {"GCP"}) is False
+    assert manager.is_cloud_ip("8.8.8.8", {"GCP:!us-central1"}) is False
+
+
+def test_cache_encode_decode_roundtrip_preserves_region() -> None:
+    net_a = ipaddress.ip_network("34.100.0.0/24")
+    net_b = ipaddress.ip_network("8.8.8.0/24")
+    ranges = {net_a, net_b}
+    regions = {str(net_a): "us-central1"}
+
+    encoded = _encode_cached(ranges, regions)
+    nets, decoded_regions = _decode_cached(encoded)
+
+    assert nets == ranges
+    assert decoded_regions == {str(net_a): "us-central1"}
+
+
+def test_decode_tolerates_legacy_unscoped_entries() -> None:
+    net = ipaddress.ip_network("34.100.0.0/24")
+    nets, regions = _decode_cached({str(net)})
+    assert nets == {net}
+    assert regions == {}
+
+
+def test_refresh_populates_network_regions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    net = ipaddress.ip_network("34.100.0.0/24")
+
+    def fake_gcp() -> tuple[set[ipaddress.IPv4Network], dict[str, str]]:
+        return {net}, {str(net): "us-central1"}
+
+    monkeypatch.setattr(
+        "guard_core.sync.handlers.cloud_handler.fetch_gcp_ip_ranges", fake_gcp
+    )
+    manager = CloudManager()
+    saved_ranges = dict(manager.ip_ranges)
+    saved_regions = dict(manager.network_regions)
+
+    manager._refresh_providers({"GCP"})
+
+    assert manager.network_regions["GCP"] == {str(net): "us-central1"}
+    assert manager.is_cloud_ip("34.100.0.5", {"GCP:!us-central1"}) is False
+
+    manager.ip_ranges = saved_ranges
+    manager.network_regions = saved_regions

--- a/tests/test_sync/test_handler_edge_cases.py
+++ b/tests/test_sync/test_handler_edge_cases.py
@@ -510,9 +510,9 @@ def test_fetch_gcp_ignores_prefixes_lacking_both_ipv4_and_ipv6() -> None:
             return response
 
     with patch("guard_core.sync.handlers.cloud_handler.requests.Session", _FakeSession):
-        result = fetch_gcp_ip_ranges()
+        networks, _ = fetch_gcp_ip_ranges()
 
-    assert len(result) == 1
+    assert len(networks) == 1
 
 
 def test_ipban_reset_noop_when_no_redis_handler() -> None:


### PR DESCRIPTION
**Stacked on #22** (base = `fix/sync-mirror-parity`; sibling of #23). Merge #22 first; GitHub retargets this to `master`. O6 regenerates the sync mirror, so it needs #22's fixed unasync generator.

## What
Design partner (high-traffic auth proxy) reported GCP IP blocking is "too strict or too lax" because it's all-or-nothing per provider. This adds **region/scope carve-outs**.

## API (flat-string selectors, backward compatible)
```python
block_cloud_providers={"GCP"}                    # block all GCP (unchanged)
block_cloud_providers={"GCP:!us-central1"}       # block GCP EXCEPT us-central1
block_cloud_providers={"GCP", "AWS:!us-east-1"}  # all GCP + all AWS except us-east-1
@block_clouds(["GCP:!us-central1"])              # decorator form
```
A carve-out implies the provider is blocked. Bare `"GCP"` is 100% unchanged. Region scoping covers **GCP + AWS** (Azure stays provider-level).

## How
- **Engine:** GCP fetch keeps the real `cloud.json` `scope`; AWS keeps `ip-ranges.json` `region` (no hardcoded region lists). A `network→region` index is built at **refresh/index time**, so per-request `is_cloud_ip` stays O(current) — one dict lookup on match.
- **Caching:** region survives Redis via inline `"network|region"` encoding under **versioned keys** (`cloud_ip_v2` / `cloud_ranges_v2`). Old entries are ignored + refetched; old replicas can't choke on the new value shape during rollout.
- **API:** `block_cloud_providers` is now `set[str]`; the config validator, the decorator, and the dynamic-rules path all validate the **provider part** of a selector (unknown providers dropped with a warning, as before).

## Decisions (confirmed with maintainer)
Flat-string selectors · carve-out semantics (`:!`) · GCP+AWS in v1 · versioned cache key.

## Verification
- 22 new tests (`tests/test_cloud_region_scope.py`); the generated sync mirror runs the same suite (async/sync parity).
- Full async suite 1818 · full sync suite 1826 · existing cloud/store/decorator/dynamic-rule tests still green.
- All pre-commit gates green (ruff-format / ruff / mypy / vulture / bandit / radon / xenon / deptry / check-sync).

## Scope
guard-core only. No dashboard/docs-site changes (SaaS surfacing is a follow-up). Relates to O5 (#23).