### PR TITLE
feat(agent): clear missing-package error, opt-in strict, on_error hook (O1/O2 engine half)

### DIFF
--- a/guard_core/core/events/middleware_events.py
+++ b/guard_core/core/events/middleware_events.py
@@ -10,7 +10,11 @@ from guard_core.core.events.event_types import (
 from guard_core.decorators.base import RouteConfig
 from guard_core.models import SecurityConfig
 from guard_core.protocols.request_protocol import GuardRequest
-from guard_core.utils import extract_client_ip, get_pipeline_response_time
+from guard_core.utils import (
+    extract_client_ip,
+    get_pipeline_response_time,
+    invoke_error_hook,
+)
 
 
 class SecurityEventBus:
@@ -33,7 +37,14 @@ class SecurityEventBus:
         try:
             country: str | None = self.geo_ip_handler.get_country(client_ip)
             return country
-        except Exception:
+        except Exception as e:
+            self.logger.warning(f"GeoIP lookup failed for {client_ip}: {e}")
+            invoke_error_hook(
+                getattr(self.config, "on_error", None),
+                "geoip",
+                e,
+                {"client_ip": client_ip},
+            )
             return None
 
     @staticmethod

--- a/guard_core/exceptions.py
+++ b/guard_core/exceptions.py
@@ -7,3 +7,7 @@ class GuardRedisError(GuardCoreError):
         self.status_code = status_code
         self.detail = detail
         super().__init__(detail)
+
+
+class AgentPackageNotInstalledError(GuardCoreError):
+    pass

--- a/guard_core/handlers/redis_handler.py
+++ b/guard_core/handlers/redis_handler.py
@@ -183,7 +183,7 @@ class RedisManager:
         async def _set(conn: Redis) -> bool:
             full_key = f"{self.config.redis_prefix}{namespace}:{key}"
             if ttl:
-                return bool(await conn.setex(full_key, ttl, value))
+                return bool(await conn.set(full_key, value, ex=ttl))
             return bool(await conn.set(full_key, value))
 
         result = await self.safe_operation(_set)

--- a/guard_core/models.py
+++ b/guard_core/models.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal, get_args
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing_extensions import Self
 
+from guard_core.exceptions import AgentPackageNotInstalledError
 from guard_core.handlers.suspatterns_handler import ALL_DETECTION_CATEGORIES
 from guard_core.protocols.cloud_ip_store_protocol import (
     CloudIpStoreFactory,
@@ -327,6 +328,25 @@ class SecurityConfig(BaseModel):
 
     agent_api_key: str | None = Field(
         default=None, description="API key for Guard Agent SaaS platform"
+    )
+
+    agent_strict: bool = Field(
+        default=False,
+        description=(
+            "When True, an enabled agent that cannot be initialized (package "
+            "missing or construction failure) raises at middleware init instead "
+            "of degrading to agent-off."
+        ),
+    )
+
+    on_error: Callable[[str, BaseException, dict[str, Any]], None] | None = Field(
+        default=None,
+        description=(
+            "Optional best-effort callback invoked when a middleware/agent step "
+            "fails, receiving (stage, exception, context). stage is one of "
+            "'agent_init', 'geoip', 'transport_send', 'encryption'. A callback "
+            "that raises is caught and logged, never propagated."
+        ),
     )
 
     agent_endpoint: str = Field(
@@ -727,8 +747,11 @@ class SecurityConfig(BaseModel):
                 project_encryption_key=self.agent_project_encryption_key,
                 guard_version=self.agent_guard_version,
             )
-        except ImportError:
-            return None
+        except ImportError as e:
+            raise AgentPackageNotInstalledError(
+                "guard-agent is not installed but enable_agent=True. "
+                "Install it with: pip install guard-agent"
+            ) from e
 
 
 class DynamicRules(BaseModel):

--- a/guard_core/sync/core/events/middleware_events.py
+++ b/guard_core/sync/core/events/middleware_events.py
@@ -10,7 +10,11 @@ from guard_core.sync.core.events.event_types import (
 )
 from guard_core.sync.decorators.base import RouteConfig
 from guard_core.sync.protocols.request_protocol import SyncGuardRequest
-from guard_core.sync.utils import extract_client_ip, get_pipeline_response_time
+from guard_core.sync.utils import (
+    extract_client_ip,
+    get_pipeline_response_time,
+    invoke_error_hook,
+)
 
 
 class SecurityEventBus:
@@ -33,7 +37,14 @@ class SecurityEventBus:
         try:
             country: str | None = self.geo_ip_handler.get_country(client_ip)
             return country
-        except Exception:
+        except Exception as e:
+            self.logger.warning(f"GeoIP lookup failed for {client_ip}: {e}")
+            invoke_error_hook(
+                getattr(self.config, "on_error", None),
+                "geoip",
+                e,
+                {"client_ip": client_ip},
+            )
             return None
 
     @staticmethod

--- a/guard_core/sync/handlers/redis_handler.py
+++ b/guard_core/sync/handlers/redis_handler.py
@@ -183,7 +183,7 @@ class RedisManager:
         def _set(conn: Redis) -> bool:
             full_key = f"{self.config.redis_prefix}{namespace}:{key}"
             if ttl:
-                return bool(conn.setex(full_key, ttl, value))
+                return bool(conn.set(full_key, value, ex=ttl))
             return bool(conn.set(full_key, value))
 
         result = self.safe_operation(_set)

--- a/guard_core/sync/utils.py
+++ b/guard_core/sync/utils.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import time
+from collections.abc import Callable
 from datetime import datetime, timezone
 from ipaddress import ip_address, ip_network
 from typing import TYPE_CHECKING, Any, Literal
@@ -13,6 +14,22 @@ from guard_core.sync.protocols.request_protocol import SyncGuardRequest
 if TYPE_CHECKING:
     from guard_core.models import SecurityConfig
     from guard_core.sync.decorators.base import RouteConfig
+
+
+def invoke_error_hook(
+    hook: Callable[[str, BaseException, dict[str, Any]], None] | None,
+    stage: str,
+    exc: BaseException,
+    context: dict[str, Any],
+) -> None:
+    if hook is None:
+        return
+    try:
+        hook(stage, exc, context)
+    except Exception as hook_error:
+        logging.getLogger("guard_core").error(
+            f"on_error hook raised while handling '{stage}': {hook_error}"
+        )
 
 
 def _sanitize_for_log(value: str) -> str:

--- a/guard_core/utils.py
+++ b/guard_core/utils.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import time
+from collections.abc import Callable
 from datetime import datetime, timezone
 from ipaddress import ip_address, ip_network
 from typing import TYPE_CHECKING, Any, Literal
@@ -13,6 +14,22 @@ from guard_core.protocols.request_protocol import GuardRequest
 if TYPE_CHECKING:
     from guard_core.decorators.base import RouteConfig
     from guard_core.models import SecurityConfig
+
+
+def invoke_error_hook(
+    hook: Callable[[str, BaseException, dict[str, Any]], None] | None,
+    stage: str,
+    exc: BaseException,
+    context: dict[str, Any],
+) -> None:
+    if hook is None:
+        return
+    try:
+        hook(stage, exc, context)
+    except Exception as hook_error:
+        logging.getLogger("guard_core").error(
+            f"on_error hook raised while handling '{stage}': {hook_error}"
+        )
 
 
 def _sanitize_for_log(value: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,9 @@ markers = [
     "asyncio: mark tests as async",
     "integration: marks tests that require Docker + external services (deselect with '-m \"not integration\"')",
 ]
+filterwarnings = [
+    "ignore:SelectableGroups dict interface is deprecated:DeprecationWarning",
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/tests/test_agent/test_models_agent_integration.py
+++ b/tests/test_agent/test_models_agent_integration.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from guard_core.exceptions import AgentPackageNotInstalledError
 from guard_core.models import SecurityConfig
 
 
@@ -129,8 +130,8 @@ def test_to_agent_config_import_error() -> None:
     sys.modules["guard_agent"] = mock_module
 
     try:
-        result = config.to_agent_config()
-        assert result is None
+        with pytest.raises(AgentPackageNotInstalledError):
+            config.to_agent_config()
     finally:
         if original_module:
             sys.modules["guard_agent"] = original_module

--- a/tests/test_agent_error_clarity.py
+++ b/tests/test_agent_error_clarity.py
@@ -1,0 +1,71 @@
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from guard_core.core.events.middleware_events import SecurityEventBus
+from guard_core.models import SecurityConfig
+from guard_core.utils import invoke_error_hook
+
+
+def test_agent_strict_defaults_false() -> None:
+    assert SecurityConfig().agent_strict is False
+
+
+def test_on_error_defaults_none() -> None:
+    assert SecurityConfig().on_error is None
+
+
+def test_on_error_accepts_callable() -> None:
+    def hook(stage: str, exc: BaseException, ctx: dict[str, Any]) -> None:
+        pass
+
+    config = SecurityConfig(on_error=hook)
+    assert config.on_error is hook
+
+
+def test_invoke_error_hook_forwards_stage_exc_context() -> None:
+    calls: list[tuple[str, BaseException, dict[str, Any]]] = []
+    err = ValueError("boom")
+
+    invoke_error_hook(
+        lambda s, e, c: calls.append((s, e, c)), "agent_init", err, {"k": "v"}
+    )
+
+    assert calls == [("agent_init", err, {"k": "v"})]
+
+
+def test_invoke_error_hook_none_is_noop() -> None:
+    invoke_error_hook(None, "geoip", ValueError("x"), {})
+
+
+def test_invoke_error_hook_swallows_raising_hook(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def bad_hook(stage: str, exc: BaseException, ctx: dict[str, Any]) -> None:
+        raise RuntimeError("hook failed")
+
+    with caplog.at_level(logging.ERROR):
+        invoke_error_hook(bad_hook, "geoip", ValueError("x"), {})
+
+    assert any("on_error hook raised" in r.message for r in caplog.records)
+
+
+def test_geoip_lookup_failure_logs_and_fires_hook(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    captured: list[tuple[str, BaseException, dict[str, Any]]] = []
+    config = SecurityConfig(on_error=lambda s, e, c: captured.append((s, e, c)))
+    geo = MagicMock()
+    geo.get_country = MagicMock(side_effect=RuntimeError("geo down"))
+    bus = SecurityEventBus(agent_handler=None, config=config, geo_ip_handler=geo)
+
+    with caplog.at_level(logging.WARNING):
+        result = bus._lookup_country("1.2.3.4")
+
+    assert result is None
+    assert any("GeoIP lookup failed" in r.message for r in caplog.records)
+    assert len(captured) == 1
+    assert captured[0][0] == "geoip"
+    assert captured[0][2] == {"client_ip": "1.2.3.4"}

--- a/tests/test_cloud_ips/test_cloud_ips.py
+++ b/tests/test_cloud_ips/test_cloud_ips.py
@@ -64,6 +64,7 @@ async def test_fetch_aws_ip_ranges(mock_aiohttp_session: MagicMock) -> None:
                     "region": "us-east-1",
                 },
                 {"ip_prefix": "10.0.0.0/8", "service": "EC2"},
+                {"ip_prefix": "172.16.0.0/12", "service": "AMAZON"},
             ]
         }
     )
@@ -73,6 +74,8 @@ async def test_fetch_aws_ip_ranges(mock_aiohttp_session: MagicMock) -> None:
     assert ipaddress.IPv4Network("192.168.0.0/24") in networks
     assert ipaddress.IPv4Network("10.0.0.0/8") not in networks
     assert regions[str(ipaddress.IPv4Network("192.168.0.0/24"))] == "us-east-1"
+    assert ipaddress.IPv4Network("172.16.0.0/12") in networks
+    assert str(ipaddress.IPv4Network("172.16.0.0/12")) not in regions
 
 
 async def test_fetch_gcp_ip_ranges(mock_aiohttp_session: MagicMock) -> None:

--- a/tests/test_composite_handler_extra.py
+++ b/tests/test_composite_handler_extra.py
@@ -109,3 +109,18 @@ async def test_health_check_false_with_single_handler() -> None:
     handler.health_check = AsyncMock(return_value=False)
     composite = CompositeAgentHandler([handler])
     assert await composite.health_check() is False
+
+
+def test_state_properties_default() -> None:
+    composite = CompositeAgentHandler([])
+    assert composite.started is False
+    assert composite.degraded is False
+    assert composite.failed_handlers == []
+
+
+def test_degraded_true_when_started_with_failed_handlers() -> None:
+    composite = CompositeAgentHandler([])
+    composite._started = True
+    composite._failed_handlers = ["handler_a"]
+    assert composite.degraded is True
+    assert composite.failed_handlers == ["handler_a"]

--- a/tests/test_sync/test_agent/test_models_agent_integration.py
+++ b/tests/test_sync/test_agent/test_models_agent_integration.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from guard_core.exceptions import AgentPackageNotInstalledError
 from guard_core.models import SecurityConfig
 
 
@@ -129,8 +130,8 @@ def test_to_agent_config_import_error() -> None:
     sys.modules["guard_agent"] = mock_module
 
     try:
-        result = config.to_agent_config()
-        assert result is None
+        with pytest.raises(AgentPackageNotInstalledError):
+            config.to_agent_config()
     finally:
         if original_module:
             sys.modules["guard_agent"] = original_module

--- a/tests/test_sync/test_agent_error_clarity.py
+++ b/tests/test_sync/test_agent_error_clarity.py
@@ -1,0 +1,71 @@
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from guard_core.models import SecurityConfig
+from guard_core.sync.core.events.middleware_events import SecurityEventBus
+from guard_core.sync.utils import invoke_error_hook
+
+
+def test_agent_strict_defaults_false() -> None:
+    assert SecurityConfig().agent_strict is False
+
+
+def test_on_error_defaults_none() -> None:
+    assert SecurityConfig().on_error is None
+
+
+def test_on_error_accepts_callable() -> None:
+    def hook(stage: str, exc: BaseException, ctx: dict[str, Any]) -> None:
+        pass
+
+    config = SecurityConfig(on_error=hook)
+    assert config.on_error is hook
+
+
+def test_invoke_error_hook_forwards_stage_exc_context() -> None:
+    calls: list[tuple[str, BaseException, dict[str, Any]]] = []
+    err = ValueError("boom")
+
+    invoke_error_hook(
+        lambda s, e, c: calls.append((s, e, c)), "agent_init", err, {"k": "v"}
+    )
+
+    assert calls == [("agent_init", err, {"k": "v"})]
+
+
+def test_invoke_error_hook_none_is_noop() -> None:
+    invoke_error_hook(None, "geoip", ValueError("x"), {})
+
+
+def test_invoke_error_hook_swallows_raising_hook(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def bad_hook(stage: str, exc: BaseException, ctx: dict[str, Any]) -> None:
+        raise RuntimeError("hook failed")
+
+    with caplog.at_level(logging.ERROR):
+        invoke_error_hook(bad_hook, "geoip", ValueError("x"), {})
+
+    assert any("on_error hook raised" in r.message for r in caplog.records)
+
+
+def test_geoip_lookup_failure_logs_and_fires_hook(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    captured: list[tuple[str, BaseException, dict[str, Any]]] = []
+    config = SecurityConfig(on_error=lambda s, e, c: captured.append((s, e, c)))
+    geo = MagicMock()
+    geo.get_country = MagicMock(side_effect=RuntimeError("geo down"))
+    bus = SecurityEventBus(agent_handler=None, config=config, geo_ip_handler=geo)
+
+    with caplog.at_level(logging.WARNING):
+        result = bus._lookup_country("1.2.3.4")
+
+    assert result is None
+    assert any("GeoIP lookup failed" in r.message for r in caplog.records)
+    assert len(captured) == 1
+    assert captured[0][0] == "geoip"
+    assert captured[0][2] == {"client_ip": "1.2.3.4"}

--- a/tests/test_sync/test_cloud_ips/test_cloud_ips.py
+++ b/tests/test_sync/test_cloud_ips/test_cloud_ips.py
@@ -64,6 +64,7 @@ def test_fetch_aws_ip_ranges(mock_aiohttp_session: MagicMock) -> None:
                     "region": "us-east-1",
                 },
                 {"ip_prefix": "10.0.0.0/8", "service": "EC2"},
+                {"ip_prefix": "172.16.0.0/12", "service": "AMAZON"},
             ]
         }
     )
@@ -73,6 +74,8 @@ def test_fetch_aws_ip_ranges(mock_aiohttp_session: MagicMock) -> None:
     assert ipaddress.IPv4Network("192.168.0.0/24") in networks
     assert ipaddress.IPv4Network("10.0.0.0/8") not in networks
     assert regions[str(ipaddress.IPv4Network("192.168.0.0/24"))] == "us-east-1"
+    assert ipaddress.IPv4Network("172.16.0.0/12") in networks
+    assert str(ipaddress.IPv4Network("172.16.0.0/12")) not in regions
 
 
 def test_fetch_gcp_ip_ranges(mock_aiohttp_session: MagicMock) -> None:

--- a/tests/test_sync/test_composite_handler_extra.py
+++ b/tests/test_sync/test_composite_handler_extra.py
@@ -109,3 +109,18 @@ def test_health_check_false_with_single_handler() -> None:
     handler.health_check = MagicMock(return_value=False)
     composite = CompositeAgentHandler([handler])
     assert composite.health_check() is False
+
+
+def test_state_properties_default() -> None:
+    composite = CompositeAgentHandler([])
+    assert composite.started is False
+    assert composite.degraded is False
+    assert composite.failed_handlers == []
+
+
+def test_degraded_true_when_started_with_failed_handlers() -> None:
+    composite = CompositeAgentHandler([])
+    composite._started = True
+    composite._failed_handlers = ["handler_a"]
+    assert composite.degraded is True
+    assert composite.failed_handlers == ["handler_a"]

--- a/tests/test_sync/test_whitelist_correctness.py
+++ b/tests/test_sync/test_whitelist_correctness.py
@@ -8,7 +8,7 @@ from guard_core.sync.core.checks.helpers import (
     is_ip_in_whitelist,
 )
 from guard_core.sync.decorators.base import RouteConfig
-from guard_core.sync.utils import extract_client_ip, is_ip_allowed
+from guard_core.sync.utils import _check_whitelist, extract_client_ip, is_ip_allowed
 from tests.test_sync.conftest import SyncMockGuardRequest
 
 
@@ -105,3 +105,25 @@ def test_global_and_route_agree_on_ipv6_whitelist_match() -> None:
     route_allowed = check_route_ip_access("0:0:0:0:0:0:0:1", route_config, middleware)
     assert global_allowed is True
     assert route_allowed is True
+
+
+def test_route_whitelist_non_ip_entry_skipped() -> None:
+    assert is_ip_in_whitelist("1.2.3.4", ip_address("1.2.3.4"), ["not-an-ip"]) is False
+
+
+def test_route_whitelist_non_ip_entry_string_fallback() -> None:
+    assert is_ip_in_whitelist("token", ip_address("1.2.3.4"), ["token"]) is True
+
+
+def test_restrictive_route_whitelist_blocks_non_member() -> None:
+    route_config = RouteConfig()
+    route_config.ip_whitelist = ["1.2.3.4"]
+    route_config.ip_blacklist = []
+    middleware = MagicMock()
+    middleware.geo_ip_handler = None
+    assert check_route_ip_access("5.6.7.8", route_config, middleware) is False
+
+
+def test_check_whitelist_without_whitelist_allows() -> None:
+    config = SecurityConfig()
+    assert _check_whitelist(ip_address("1.2.3.4"), "1.2.3.4", config) is True

--- a/tests/test_whitelist_correctness.py
+++ b/tests/test_whitelist_correctness.py
@@ -8,7 +8,7 @@ from guard_core.core.checks.helpers import (
 )
 from guard_core.decorators.base import RouteConfig
 from guard_core.models import SecurityConfig
-from guard_core.utils import extract_client_ip, is_ip_allowed
+from guard_core.utils import _check_whitelist, extract_client_ip, is_ip_allowed
 from tests.conftest import MockGuardRequest
 
 
@@ -111,3 +111,25 @@ async def test_global_and_route_agree_on_ipv6_whitelist_match() -> None:
     )
     assert global_allowed is True
     assert route_allowed is True
+
+
+async def test_route_whitelist_non_ip_entry_skipped() -> None:
+    assert is_ip_in_whitelist("1.2.3.4", ip_address("1.2.3.4"), ["not-an-ip"]) is False
+
+
+async def test_route_whitelist_non_ip_entry_string_fallback() -> None:
+    assert is_ip_in_whitelist("token", ip_address("1.2.3.4"), ["token"]) is True
+
+
+async def test_restrictive_route_whitelist_blocks_non_member() -> None:
+    route_config = RouteConfig()
+    route_config.ip_whitelist = ["1.2.3.4"]
+    route_config.ip_blacklist = []
+    middleware = MagicMock()
+    middleware.geo_ip_handler = None
+    assert await check_route_ip_access("5.6.7.8", route_config, middleware) is False
+
+
+async def test_check_whitelist_without_whitelist_allows() -> None:
+    config = SecurityConfig()
+    assert await _check_whitelist(ip_address("1.2.3.4"), "1.2.3.4", config) is True


### PR DESCRIPTION
Engine foundation for the **agent-error-clarity** design-partner feedback (O1 + O2). The fastapi-guard adapter half and the guard-agent transport half build on this.

## What
A design partner couldn't tell when agent telemetry failed: a missing `guard-agent` package produced a silent warning *and* a misleading "check agent_api_key" error, and other failures (GeoIP) were swallowed silently.

- **Clear missing-package signal (O1).** `to_agent_config()` now raises `AgentPackageNotInstalledError` (naming the package + install command) instead of returning an ambiguous `None`. A missing `guard-agent` can no longer masquerade as "configuration is invalid / check agent_api_key" in adapters.
- **Opt-in strict (O1/O2).** `SecurityConfig.agent_strict` (default `False`) — adapters raise at init instead of degrading to agent-off when `True`. Fail-soft stays the default for availability-sensitive deployments.
- **Single `on_error` hook (O2).** `SecurityConfig.on_error` (default `None`) is one best-effort `on_error(stage, exc, context)` callback (`stage` ∈ `agent_init`/`geoip`/`transport_send`/`encryption`). `utils.invoke_error_hook` invokes it and **never** lets a raising hook propagate into the request path.
- **Stop the silent GeoIP drop (O2).** `SecurityEventBus._lookup_country` now logs at warning **and** fires `on_error(stage="geoip")` instead of a bare `except Exception: return None`.

## Decisions (confirmed with maintainer)
Fail-soft default + opt-in strict · fix in guard-core engine (all adapters benefit) · single `on_error(stage, exc, context)` hook · (`fastapi-guard[agent]` extra lands in the adapter PR).

## Verification
- New `tests/test_agent_error_clarity.py` (+ updated `to_agent_config` import-error test); generated sync mirror runs the same suite (parity).
- Full async suite **1838 passed**, full sync suite green, all pre-commit gates incl. `check-sync` green.

## Follow-ups (same feature, separate repos)
- **guard-agent:** `AgentConfig.on_error` + fire at transport send/flush + encryption-abort swallow points.
- **fastapi-guard:** `[agent]` extra + middleware restructure (catch `AgentPackageNotInstalledError` → one clear error; honor `agent_strict`; fire `on_error`; surface agent-degraded state via `get_stats`/`health_check`).

Version bump deferred until the three repos land together.