### PR TITLE
docs(behavioral): fix non-existent @security.behavioral reference (O8)

### DIFF
--- a/docs/internals/behavioral.md
+++ b/docs/internals/behavioral.md
@@ -136,7 +136,7 @@ from guard_core.handlers.behavior_handler import BehaviorRule
 
 security = SecurityDecorator(config)
 
-@security.behavioral(rules=[
+@security.behavior_analysis(rules=[
     BehaviorRule(
         rule_type="usage",
         threshold=100,


### PR DESCRIPTION
## Summary

Design-partner feedback **O8** (guard-core half). `docs/internals/behavioral.md` showed `@security.behavioral(rules=[...])`, but no `behavioral()` method exists on `SecurityDecorator` — a reader copying the snippet hits an `AttributeError`. The real method is **`behavior_analysis(rules=[...])`** (`guard_core/decorators/behavioral.py:48`). Corrected.

The rest of O8 — the adoption-path gap (the `set_decorator_handler` wiring missing from the tutorial + runnable example) — is on the fastapi-guard side.

### Scope
One-line docs fix. Markdown lint clean.