### PR TITLE
feat(detection): B3.1 graduated anomaly-scoring machinery (behavior-neutral)

### DIFF
--- a/guard_core/handlers/suspatterns_handler.py
+++ b/guard_core/handlers/suspatterns_handler.py
@@ -88,6 +88,10 @@ def _resolve_pattern_weight(pattern: str, category: str) -> float:
     return DETECTION_CATEGORY_WEIGHTS.get(category, 1.0)
 
 
+def _regex_anomaly(regex_threats: list) -> float:
+    return sum(t.get("weight", 1.0) for t in regex_threats)
+
+
 class SusPatternsManager:
     _instance = None
     _config = None
@@ -444,12 +448,16 @@ class SusPatternsManager:
                     max_tracked_patterns=config.detection_max_tracked_patterns,
                 )
                 cls._instance._semantic_threshold = config.detection_semantic_threshold
+                cls._instance._threat_score_threshold = (
+                    config.detection_threat_score_threshold
+                )
             else:
                 cls._instance._compiler = None
                 cls._instance._preprocessor = None
                 cls._instance._semantic_analyzer = None
                 cls._instance._performance_monitor = None
                 cls._instance._semantic_threshold = 0.7
+                cls._instance._threat_score_threshold = 1.0
 
         return cls._instance
 
@@ -695,12 +703,12 @@ class SusPatternsManager:
         if not (regex_threats or semantic_threats):
             return 0.0
 
-        regex_score = 1.0 if regex_threats else 0.0
+        anomaly = _regex_anomaly(regex_threats)
         semantic_scores = [
             t.get("probability", t.get("threat_score", 0.0)) for t in semantic_threats
         ]
         semantic_max = max(semantic_scores) if semantic_scores else 0.0
-        return max(regex_score, semantic_max)
+        return min(max(anomaly, semantic_max), 1.0)
 
     async def detect(
         self,
@@ -728,7 +736,10 @@ class SusPatternsManager:
         )
 
         threats = regex_threats + semantic_threats
-        is_threat = len(threats) > 0
+        is_threat = (
+            _regex_anomaly(regex_threats) >= self._threat_score_threshold
+            or len(semantic_threats) > 0
+        )
 
         threat_score = await self._calculate_threat_score(
             regex_threats, semantic_threats

--- a/guard_core/handlers/suspatterns_handler.py
+++ b/guard_core/handlers/suspatterns_handler.py
@@ -75,6 +75,18 @@ CATEGORY_CONTEXT_MAP: dict[str, frozenset[str]] = {
     "code_injection": _CTX_CODE_INJECTION,
 }
 
+DETECTION_CATEGORY_WEIGHTS: dict[str, float] = {
+    category: 1.0 for category in ALL_DETECTION_CATEGORIES
+}
+
+DETECTION_PATTERN_WEIGHT_OVERRIDES: dict[str, float] = {}
+
+
+def _resolve_pattern_weight(pattern: str, category: str) -> float:
+    if pattern in DETECTION_PATTERN_WEIGHT_OVERRIDES:
+        return DETECTION_PATTERN_WEIGHT_OVERRIDES[pattern]
+    return DETECTION_CATEGORY_WEIGHTS.get(category, 1.0)
+
 
 class SusPatternsManager:
     _instance = None
@@ -527,6 +539,7 @@ class SusPatternsManager:
                     "position": match.start(),
                     "execution_time": time.time() - pattern_start,
                     "category": category,
+                    "weight": _resolve_pattern_weight(pattern.pattern, category),
                 }, timeout_occurred
         else:
             match, timeout_occurred = await self._check_pattern_with_timeout(
@@ -540,6 +553,7 @@ class SusPatternsManager:
                     "position": match.start(),
                     "execution_time": time.time() - pattern_start,
                     "category": category,
+                    "weight": _resolve_pattern_weight(pattern.pattern, category),
                 }, timeout_occurred
 
         return None, timeout_occurred

--- a/guard_core/handlers/suspatterns_handler.py
+++ b/guard_core/handlers/suspatterns_handler.py
@@ -75,11 +75,19 @@ CATEGORY_CONTEXT_MAP: dict[str, frozenset[str]] = {
     "code_injection": _CTX_CODE_INJECTION,
 }
 
+_SELECT_FROM_RE = r"(?i)SELECT\s+[\w\s,\*]+\s+FROM\s+[\w\s\._]+"
+_SELECT_STAR_RE = r"(?i)SELECT\s+\*"
+_WHERE_CLAUSE_RE = r'(?i)\bWHERE\s+[\w."]+\s*(?:=|<|>|<=|>=|LIKE|IN)\b'
+
 DETECTION_CATEGORY_WEIGHTS: dict[str, float] = {
     category: 1.0 for category in ALL_DETECTION_CATEGORIES
 }
 
-DETECTION_PATTERN_WEIGHT_OVERRIDES: dict[str, float] = {}
+DETECTION_PATTERN_WEIGHT_OVERRIDES: dict[str, float] = {
+    _SELECT_FROM_RE: 0.5,
+    _SELECT_STAR_RE: 0.5,
+    _WHERE_CLAUSE_RE: 0.5,
+}
 
 
 def _resolve_pattern_weight(pattern: str, category: str) -> float:
@@ -120,7 +128,9 @@ class SusPatternsManager:
         (r"(?:<object[^>]*>[\s\S]*<\/object\s*>)", _CTX_XSS, "xss"),
         (r"(?:<embed[^>]*>[\s\S]*<\/embed\s*>)", _CTX_XSS, "xss"),
         (r"(?:<applet[^>]*>[\s\S]*<\/applet\s*>)", _CTX_XSS, "xss"),
-        (r"(?i)SELECT\s+[\w\s,\*]+\s+FROM\s+[\w\s\._]+", _CTX_SQLI, "sqli"),
+        (_SELECT_FROM_RE, _CTX_SQLI, "sqli"),
+        (_SELECT_STAR_RE, _CTX_SQLI, "sqli"),
+        (_WHERE_CLAUSE_RE, _CTX_SQLI, "sqli"),
         (r"(?i)UNION\s+(?:ALL\s+)?SELECT", _CTX_SQLI, "sqli"),
         (
             r"(?i)('\s*(?:OR|AND)\s*[\(\s]*'?[\d\w]+\s*(?:=|LIKE|<|>|<=|>=)\s*"
@@ -147,7 +157,7 @@ class SusPatternsManager:
         (r"\w/\*(?!!)[^*]*\*/\w", _CTX_SQLI, "sqli"),
         (r"(?i)(?:OR|AND)\s+'[\w\d]*'='[\w\d]*'?", _CTX_SQLI, "sqli"),
         (
-            r"(?i)(?:^|;)\s*(?:DROP|TRUNCATE|ALTER)\s+(?:TABLE|DATABASE|SCHEMA)\b",
+            r"(?i);\s*(?:DROP|TRUNCATE|ALTER)\s+(?:TABLE|DATABASE|SCHEMA)\b",
             _CTX_SQLI,
             "sqli",
         ),
@@ -156,7 +166,7 @@ class SusPatternsManager:
             _CTX_SQLI,
             "sqli",
         ),
-        (r"(?i)\bORDER\s+BY\s+\d+\b", _CTX_SQLI, "sqli"),
+        (r"(?i)\bORDER\s+BY\s+\d+\s*(?:--|#|;|\)|,|/\*|$)", _CTX_SQLI, "sqli"),
         (r"(?:\.\.\/|\.\.\\)(?:\.\.\/|\.\.\\)+", _CTX_DIR_TRAVERSAL, "dir_traversal"),
         (
             r"(?:/etc/(?:passwd|shadow|group|hosts|motd|issue|mysql/my.cnf|ssh/"
@@ -240,7 +250,13 @@ class SusPatternsManager:
         ),
         (r"(?:\{\s*\$[a-zA-Z]+\s*:\s*(?:\{|\[))", _CTX_NOSQL, "nosql"),
         (
-            r'"\$(?:where|gt|gte|lt|lte|ne|eq|regex|in|nin|all|size|exists|type|mod|options|expr|jsonSchema)"\s*:',
+            r'"\$(?:where|regex|expr|jsonSchema|function|accumulator|type|exists|size)"\s*:',
+            _CTX_NOSQL,
+            "nosql",
+        ),
+        (
+            r'"\$(?:gt|gte|lt|lte|ne|eq|in|nin|all|mod)"'
+            r'\s*:\s*(?:""|null|\{|\[)',
             _CTX_NOSQL,
             "nosql",
         ),
@@ -266,7 +282,12 @@ class SusPatternsManager:
             _CTX_TEMPLATE,
             "template",
         ),
-        (r"<%[=#]?[^%]*%>", _CTX_TEMPLATE, "template"),
+        (
+            r"(?i)<%[=#]?[^%]*(?:system|exec|eval|`|Runtime|IO\.|File\.|Dir\."
+            r"|\d+\s*[-+*/]\s*\d+)[^%]*%>",
+            _CTX_TEMPLATE,
+            "template",
+        ),
         (
             r"\$\{[^}]*(?:@[\w.]+@|\b\w+\s*\(|\d+\s*[*/%+\-]\s*\d+)[^}]*\}",
             _CTX_TEMPLATE,

--- a/guard_core/models.py
+++ b/guard_core/models.py
@@ -499,6 +499,13 @@ class SecurityConfig(BaseModel):
         le=5000,
     )
 
+    detection_threat_score_threshold: float = Field(
+        default=1.0,
+        description="Anomaly score required to flag a request as a threat",
+        ge=0.0,
+        le=10.0,
+    )
+
     muted_event_types: set[str] = Field(
         default_factory=set,
         description="Event types to mute from telemetry dispatch",

--- a/guard_core/sync/handlers/suspatterns_handler.py
+++ b/guard_core/sync/handlers/suspatterns_handler.py
@@ -75,6 +75,18 @@ CATEGORY_CONTEXT_MAP: dict[str, frozenset[str]] = {
     "code_injection": _CTX_CODE_INJECTION,
 }
 
+DETECTION_CATEGORY_WEIGHTS: dict[str, float] = {
+    category: 1.0 for category in ALL_DETECTION_CATEGORIES
+}
+
+DETECTION_PATTERN_WEIGHT_OVERRIDES: dict[str, float] = {}
+
+
+def _resolve_pattern_weight(pattern: str, category: str) -> float:
+    if pattern in DETECTION_PATTERN_WEIGHT_OVERRIDES:
+        return DETECTION_PATTERN_WEIGHT_OVERRIDES[pattern]
+    return DETECTION_CATEGORY_WEIGHTS.get(category, 1.0)
+
 
 class SusPatternsManager:
     _instance = None
@@ -525,6 +537,7 @@ class SusPatternsManager:
                     "position": match.start(),
                     "execution_time": time.time() - pattern_start,
                     "category": category,
+                    "weight": _resolve_pattern_weight(pattern.pattern, category),
                 }, timeout_occurred
         else:
             match, timeout_occurred = self._check_pattern_with_timeout(
@@ -538,6 +551,7 @@ class SusPatternsManager:
                     "position": match.start(),
                     "execution_time": time.time() - pattern_start,
                     "category": category,
+                    "weight": _resolve_pattern_weight(pattern.pattern, category),
                 }, timeout_occurred
 
         return None, timeout_occurred

--- a/guard_core/sync/handlers/suspatterns_handler.py
+++ b/guard_core/sync/handlers/suspatterns_handler.py
@@ -88,6 +88,10 @@ def _resolve_pattern_weight(pattern: str, category: str) -> float:
     return DETECTION_CATEGORY_WEIGHTS.get(category, 1.0)
 
 
+def _regex_anomaly(regex_threats: list) -> float:
+    return sum(t.get("weight", 1.0) for t in regex_threats)
+
+
 class SusPatternsManager:
     _instance = None
     _config = None
@@ -444,12 +448,16 @@ class SusPatternsManager:
                     max_tracked_patterns=config.detection_max_tracked_patterns,
                 )
                 cls._instance._semantic_threshold = config.detection_semantic_threshold
+                cls._instance._threat_score_threshold = (
+                    config.detection_threat_score_threshold
+                )
             else:
                 cls._instance._compiler = None
                 cls._instance._preprocessor = None
                 cls._instance._semantic_analyzer = None
                 cls._instance._performance_monitor = None
                 cls._instance._semantic_threshold = 0.7
+                cls._instance._threat_score_threshold = 1.0
 
         return cls._instance
 
@@ -693,12 +701,12 @@ class SusPatternsManager:
         if not (regex_threats or semantic_threats):
             return 0.0
 
-        regex_score = 1.0 if regex_threats else 0.0
+        anomaly = _regex_anomaly(regex_threats)
         semantic_scores = [
             t.get("probability", t.get("threat_score", 0.0)) for t in semantic_threats
         ]
         semantic_max = max(semantic_scores) if semantic_scores else 0.0
-        return max(regex_score, semantic_max)
+        return min(max(anomaly, semantic_max), 1.0)
 
     def detect(
         self,
@@ -726,7 +734,10 @@ class SusPatternsManager:
         )
 
         threats = regex_threats + semantic_threats
-        is_threat = len(threats) > 0
+        is_threat = (
+            _regex_anomaly(regex_threats) >= self._threat_score_threshold
+            or len(semantic_threats) > 0
+        )
 
         threat_score = self._calculate_threat_score(regex_threats, semantic_threats)
 

--- a/guard_core/sync/handlers/suspatterns_handler.py
+++ b/guard_core/sync/handlers/suspatterns_handler.py
@@ -75,11 +75,19 @@ CATEGORY_CONTEXT_MAP: dict[str, frozenset[str]] = {
     "code_injection": _CTX_CODE_INJECTION,
 }
 
+_SELECT_FROM_RE = r"(?i)SELECT\s+[\w\s,\*]+\s+FROM\s+[\w\s\._]+"
+_SELECT_STAR_RE = r"(?i)SELECT\s+\*"
+_WHERE_CLAUSE_RE = r'(?i)\bWHERE\s+[\w."]+\s*(?:=|<|>|<=|>=|LIKE|IN)\b'
+
 DETECTION_CATEGORY_WEIGHTS: dict[str, float] = {
     category: 1.0 for category in ALL_DETECTION_CATEGORIES
 }
 
-DETECTION_PATTERN_WEIGHT_OVERRIDES: dict[str, float] = {}
+DETECTION_PATTERN_WEIGHT_OVERRIDES: dict[str, float] = {
+    _SELECT_FROM_RE: 0.5,
+    _SELECT_STAR_RE: 0.5,
+    _WHERE_CLAUSE_RE: 0.5,
+}
 
 
 def _resolve_pattern_weight(pattern: str, category: str) -> float:
@@ -120,7 +128,9 @@ class SusPatternsManager:
         (r"(?:<object[^>]*>[\s\S]*<\/object\s*>)", _CTX_XSS, "xss"),
         (r"(?:<embed[^>]*>[\s\S]*<\/embed\s*>)", _CTX_XSS, "xss"),
         (r"(?:<applet[^>]*>[\s\S]*<\/applet\s*>)", _CTX_XSS, "xss"),
-        (r"(?i)SELECT\s+[\w\s,\*]+\s+FROM\s+[\w\s\._]+", _CTX_SQLI, "sqli"),
+        (_SELECT_FROM_RE, _CTX_SQLI, "sqli"),
+        (_SELECT_STAR_RE, _CTX_SQLI, "sqli"),
+        (_WHERE_CLAUSE_RE, _CTX_SQLI, "sqli"),
         (r"(?i)UNION\s+(?:ALL\s+)?SELECT", _CTX_SQLI, "sqli"),
         (
             r"(?i)('\s*(?:OR|AND)\s*[\(\s]*'?[\d\w]+\s*(?:=|LIKE|<|>|<=|>=)\s*"
@@ -147,7 +157,7 @@ class SusPatternsManager:
         (r"\w/\*(?!!)[^*]*\*/\w", _CTX_SQLI, "sqli"),
         (r"(?i)(?:OR|AND)\s+'[\w\d]*'='[\w\d]*'?", _CTX_SQLI, "sqli"),
         (
-            r"(?i)(?:^|;)\s*(?:DROP|TRUNCATE|ALTER)\s+(?:TABLE|DATABASE|SCHEMA)\b",
+            r"(?i);\s*(?:DROP|TRUNCATE|ALTER)\s+(?:TABLE|DATABASE|SCHEMA)\b",
             _CTX_SQLI,
             "sqli",
         ),
@@ -156,7 +166,7 @@ class SusPatternsManager:
             _CTX_SQLI,
             "sqli",
         ),
-        (r"(?i)\bORDER\s+BY\s+\d+\b", _CTX_SQLI, "sqli"),
+        (r"(?i)\bORDER\s+BY\s+\d+\s*(?:--|#|;|\)|,|/\*|$)", _CTX_SQLI, "sqli"),
         (r"(?:\.\.\/|\.\.\\)(?:\.\.\/|\.\.\\)+", _CTX_DIR_TRAVERSAL, "dir_traversal"),
         (
             r"(?:/etc/(?:passwd|shadow|group|hosts|motd|issue|mysql/my.cnf|ssh/"
@@ -240,7 +250,13 @@ class SusPatternsManager:
         ),
         (r"(?:\{\s*\$[a-zA-Z]+\s*:\s*(?:\{|\[))", _CTX_NOSQL, "nosql"),
         (
-            r'"\$(?:where|gt|gte|lt|lte|ne|eq|regex|in|nin|all|size|exists|type|mod|options|expr|jsonSchema)"\s*:',
+            r'"\$(?:where|regex|expr|jsonSchema|function|accumulator|type|exists|size)"\s*:',
+            _CTX_NOSQL,
+            "nosql",
+        ),
+        (
+            r'"\$(?:gt|gte|lt|lte|ne|eq|in|nin|all|mod)"'
+            r'\s*:\s*(?:""|null|\{|\[)',
             _CTX_NOSQL,
             "nosql",
         ),
@@ -266,7 +282,12 @@ class SusPatternsManager:
             _CTX_TEMPLATE,
             "template",
         ),
-        (r"<%[=#]?[^%]*%>", _CTX_TEMPLATE, "template"),
+        (
+            r"(?i)<%[=#]?[^%]*(?:system|exec|eval|`|Runtime|IO\.|File\.|Dir\."
+            r"|\d+\s*[-+*/]\s*\d+)[^%]*%>",
+            _CTX_TEMPLATE,
+            "template",
+        ),
         (
             r"\$\{[^}]*(?:@[\w.]+@|\b\w+\s*\(|\d+\s*[*/%+\-]\s*\d+)[^}]*\}",
             _CTX_TEMPLATE,

--- a/tests/attack_simulation/baseline.json
+++ b/tests/attack_simulation/baseline.json
@@ -1,4 +1,4 @@
 {
   "detection_rate": 0.8568421052631578,
-  "fp_rate": 0.125
+  "fp_rate": 0.0
 }

--- a/tests/attack_simulation/corpus/benign/legit_code_comments.txt
+++ b/tests/attack_simulation/corpus/benign/legit_code_comments.txt
@@ -1,0 +1,7 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+color: red; /* main theme */ font-size: 14px
+const total = price /* legacy adjustment */ + tax
+avoid modifying Object.prototype or __proto__ in your code
+call the helper to launch the app when ready
+the config sets a = b in the default section

--- a/tests/attack_simulation/corpus/benign/legit_json_mongo.txt
+++ b/tests/attack_simulation/corpus/benign/legit_json_mongo.txt
@@ -1,0 +1,9 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+{"price":"$25","name":"coffee","size":"large"}
+{"filter":{"$gt":5},"limit":20}
+{"age":{"$gte":18},"active":true}
+{"sort":{"created":-1},"page":2}
+{"type":"string","name":"coffee","price":"$25"}
+{"user":"renzo","role":"admin","tier":"team"}
+{"range":{"$lt":100,"$gt":10}}

--- a/tests/attack_simulation/corpus/benign/legit_templates_docs.txt
+++ b/tests/attack_simulation/corpus/benign/legit_templates_docs.txt
@@ -1,0 +1,7 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+render <%= @user.name %> inside your erb view
+the template shows <%= product.title %> at the top
+use ${user.displayName} for the greeting in the layout
+set the variable with export PATH=${HOME}/bin
+the docs mention {{ page.title }} as a placeholder

--- a/tests/attack_simulation/corpus/benign/legit_urls_params.txt
+++ b/tests/attack_simulation/corpus/benign/legit_urls_params.txt
@@ -1,0 +1,7 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+search?q=hello%20world%20coffee&sort=relevance
+/api/v1/orders/history?from=2026-01-01&to=2026-06-30
+/docs/getting-started/installation#configuration
+filter?category=books&order=title&direction=asc
+the price range is $10 to $50 for the order

--- a/tests/attack_simulation/corpus/benign/prose_shell_extended.txt
+++ b/tests/attack_simulation/corpus/benign/prose_shell_extended.txt
@@ -1,0 +1,10 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+first do this; then list the remaining steps for the team
+run ls -la in your notes to remember the layout
+to listen on the port use nc as described in the manual
+please remove the old files and copy the summary over
+let me cat the photos of my pet and the dog she adopted
+evaluate the plan before you execute the next phase
+the system will ping you when the export is ready
+we ship via socat logistics on tuesdays and fridays

--- a/tests/attack_simulation/corpus/benign/prose_sql_extended.txt
+++ b/tests/attack_simulation/corpus/benign/prose_sql_extended.txt
@@ -1,0 +1,12 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+I'll select a few items from the catalog for you
+we will select candidates from the applicant pool where appropriate
+please sort the results, order by 1 ascending then by name
+drop table 7 is reserved for the wedding party tonight
+the union meeting is scheduled; bring your badge and lunch
+we should update users about the new schedule next week
+let me select the best photo from the album for the cover
+the order form asks you to select a size from the dropdown
+group discounts apply when you order by the dozen
+insert the card into the reader and wait for the beep

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,8 +136,6 @@ class MockGuardResponseFactory:
 async def reset_state() -> AsyncGenerator[None, None]:
     IPBanManager._instance = None
 
-    original_patterns = sus_patterns_handler.patterns.copy()
-
     cloud_instance = cloud_handler._instance
     if cloud_instance:
         from guard_core.handlers.cloud_ip_stores import InMemoryCloudIpStore
@@ -154,7 +152,12 @@ async def reset_state() -> AsyncGenerator[None, None]:
         IPInfoManager._instance = None
 
     yield
-    sus_patterns_handler.patterns = original_patterns.copy()
+    spm = type(sus_patterns_handler)
+    spm._instance = sus_patterns_handler
+    spm._config = None
+    sus_patterns_handler.patterns = [p[0] for p in spm._pattern_definitions]
+    sus_patterns_handler.custom_patterns = set()
+    sus_patterns_handler.compiled_custom_patterns = set()
 
     IPBanManager._instance = None
 

--- a/tests/test_preprocessor_encodings.py
+++ b/tests/test_preprocessor_encodings.py
@@ -30,11 +30,11 @@ async def test_js_unicode_escape_decoded(pp: ContentPreprocessor) -> None:
 
 
 @pytest.mark.asyncio
-async def test_sql_block_comment_stripped(pp: ContentPreprocessor) -> None:
+async def test_sql_block_comment_retained_not_fused(pp: ContentPreprocessor) -> None:
     payload = "SELE/**/CT password FRO/**/M users"
     result = await pp.preprocess(payload)
-    assert "select" in result.lower()
-    assert "from" in result.lower()
+    assert "/**/" in result
+    assert "select" not in result.lower()
 
 
 @pytest.mark.asyncio
@@ -106,7 +106,7 @@ def test_decode_unicode_escapes_directly(pp: ContentPreprocessor) -> None:
 
 
 def test_strip_sql_comments_block(pp: ContentPreprocessor) -> None:
-    assert pp._strip_sql_comments("SEL/*x*/ECT") == "SELECT"
+    assert pp._strip_sql_comments("SEL/*x*/ECT") == "SEL/*x*/ECT"
 
 
 def test_strip_sql_comments_line(pp: ContentPreprocessor) -> None:
@@ -159,37 +159,33 @@ def test_unicode_escape_value_error_path(pp: ContentPreprocessor) -> None:
 
 
 @pytest.mark.asyncio
-async def test_sql_between_token_comment_preserves_word_boundaries(
+async def test_sql_between_token_comment_retained(
     pp: ContentPreprocessor,
 ) -> None:
     payload = "WHERE id=1/**/OR/**/x=2"
     result = await pp.preprocess(payload)
-    lower = result.lower()
-    assert "1or" not in lower
-    assert "orx" not in lower
-    assert " or " in lower
+    assert "/**/" in result
+    assert "1or" not in result.lower()
 
 
 @pytest.mark.asyncio
-async def test_sql_lowercase_keyword_comment_reconstructs(
+async def test_sql_lowercase_keyword_comment_retained(
     pp: ContentPreprocessor,
 ) -> None:
     payload = "sele/**/ct password fro/**/m users"
     result = await pp.preprocess(payload)
-    lower = result.lower()
-    assert "select" in lower
-    assert "from" in lower
+    assert "/**/" in result
+    assert "select" not in result.lower()
 
 
 @pytest.mark.asyncio
-async def test_sql_uppercase_keyword_then_lowercase_identifier_no_fusion(
+async def test_sql_uppercase_keyword_comment_retained(
     pp: ContentPreprocessor,
 ) -> None:
     payload = "WHERE id=1 OR/**/x=2"
     result = await pp.preprocess(payload)
-    lower = result.lower()
-    assert "orx" not in lower
-    assert " or " in lower or lower.endswith(" or") or lower.startswith("or ")
+    assert "/**/" in result
+    assert "orx" not in result.lower()
 
 
 @pytest.mark.asyncio

--- a/tests/test_sus_patterns/test_anomaly_scoring.py
+++ b/tests/test_sus_patterns/test_anomaly_scoring.py
@@ -27,3 +27,34 @@ async def test_regex_threat_dict_carries_weight(sus_patterns_manager_with_detect
     regex_threats = [t for t in result["threats"] if t["type"] == "regex"]
     assert regex_threats
     assert all(t["weight"] == 1.0 for t in regex_threats)
+
+
+from guard_core.handlers.suspatterns_handler import SusPatternsManager
+
+
+@pytest.mark.asyncio
+async def test_single_match_still_flagged_at_default_threshold(
+    sus_patterns_manager_with_detection,
+):
+    result = await sus_patterns_manager_with_detection.detect(
+        "<script>alert(1)</script>", "127.0.0.1", context="unknown"
+    )
+    assert result["is_threat"] is True
+    assert result["threat_score"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_threshold_gate_suppresses_below_threshold():
+    SusPatternsManager._instance = None
+    SusPatternsManager._config = None
+    config = SecurityConfig(detection_threat_score_threshold=2.0)
+    manager = SusPatternsManager(config)
+    try:
+        result = await manager.detect(
+            "<script>alert(1)</script>", "127.0.0.1", context="unknown"
+        )
+        assert result["is_threat"] is False
+    finally:
+        await manager.reset()
+        SusPatternsManager._instance = None
+        SusPatternsManager._config = None

--- a/tests/test_sus_patterns/test_anomaly_scoring.py
+++ b/tests/test_sus_patterns/test_anomaly_scoring.py
@@ -1,16 +1,19 @@
 import pytest
+from pydantic import ValidationError
 
-from guard_core.models import SecurityConfig
 from guard_core.handlers.suspatterns_handler import (
     DETECTION_CATEGORY_WEIGHTS,
+    SusPatternsManager,
     _resolve_pattern_weight,
 )
+from guard_core.models import SecurityConfig
 
 
 def test_threshold_field_default_and_bounds():
     assert SecurityConfig().detection_threat_score_threshold == 1.0
-    assert SecurityConfig(detection_threat_score_threshold=2.5).detection_threat_score_threshold == 2.5
-    with pytest.raises(Exception):
+    raised = SecurityConfig(detection_threat_score_threshold=2.5)
+    assert raised.detection_threat_score_threshold == 2.5
+    with pytest.raises(ValidationError):
         SecurityConfig(detection_threat_score_threshold=-1.0)
 
 
@@ -27,9 +30,6 @@ async def test_regex_threat_dict_carries_weight(sus_patterns_manager_with_detect
     regex_threats = [t for t in result["threats"] if t["type"] == "regex"]
     assert regex_threats
     assert all(t["weight"] == 1.0 for t in regex_threats)
-
-
-from guard_core.handlers.suspatterns_handler import SusPatternsManager
 
 
 @pytest.mark.asyncio

--- a/tests/test_sus_patterns/test_anomaly_scoring.py
+++ b/tests/test_sus_patterns/test_anomaly_scoring.py
@@ -1,0 +1,10 @@
+import pytest
+
+from guard_core.models import SecurityConfig
+
+
+def test_threshold_field_default_and_bounds():
+    assert SecurityConfig().detection_threat_score_threshold == 1.0
+    assert SecurityConfig(detection_threat_score_threshold=2.5).detection_threat_score_threshold == 2.5
+    with pytest.raises(Exception):
+        SecurityConfig(detection_threat_score_threshold=-1.0)

--- a/tests/test_sus_patterns/test_anomaly_scoring.py
+++ b/tests/test_sus_patterns/test_anomaly_scoring.py
@@ -1,6 +1,10 @@
 import pytest
 
 from guard_core.models import SecurityConfig
+from guard_core.handlers.suspatterns_handler import (
+    DETECTION_CATEGORY_WEIGHTS,
+    _resolve_pattern_weight,
+)
 
 
 def test_threshold_field_default_and_bounds():
@@ -8,3 +12,18 @@ def test_threshold_field_default_and_bounds():
     assert SecurityConfig(detection_threat_score_threshold=2.5).detection_threat_score_threshold == 2.5
     with pytest.raises(Exception):
         SecurityConfig(detection_threat_score_threshold=-1.0)
+
+
+def test_resolve_weight_defaults_to_category_one():
+    assert _resolve_pattern_weight(r"some-pattern", "sqli") == 1.0
+    assert DETECTION_CATEGORY_WEIGHTS["sqli"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_regex_threat_dict_carries_weight(sus_patterns_manager_with_detection):
+    result = await sus_patterns_manager_with_detection.detect(
+        "<script>alert(1)</script>", "127.0.0.1", context="unknown"
+    )
+    regex_threats = [t for t in result["threats"] if t["type"] == "regex"]
+    assert regex_threats
+    assert all(t["weight"] == 1.0 for t in regex_threats)

--- a/tests/test_sus_patterns/test_fp_reduction.py
+++ b/tests/test_sus_patterns/test_fp_reduction.py
@@ -1,0 +1,93 @@
+import pytest
+
+
+async def _flagged(manager, payload: str) -> bool:
+    result = await manager.detect(payload, "127.0.0.1", context="unknown")
+    return result["is_threat"]
+
+
+@pytest.mark.asyncio
+async def test_select_star_still_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(sus_patterns_manager_with_detection, "SELECT * FROM users")
+
+
+@pytest.mark.asyncio
+async def test_select_where_still_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(
+        sus_patterns_manager_with_detection, "SELECT password FROM users WHERE id=1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_select_prose_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        "I'll select a few items from the catalog for you",
+    )
+
+
+@pytest.mark.asyncio
+async def test_select_candidates_prose_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        "we will select candidates from the applicant pool",
+    )
+
+
+@pytest.mark.asyncio
+async def test_order_by_attack_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(sus_patterns_manager_with_detection, "1' ORDER BY 1--")
+
+
+@pytest.mark.asyncio
+async def test_order_by_prose_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        "sort the results, order by 1 ascending then by name",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ddl_attack_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(sus_patterns_manager_with_detection, "'; DROP TABLE users;--")
+
+
+@pytest.mark.asyncio
+async def test_ddl_prose_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        "drop table 7 is reserved for the wedding party",
+    )
+
+
+@pytest.mark.asyncio
+async def test_erb_attack_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(sus_patterns_manager_with_detection, "<%= 7*7 %>")
+
+
+@pytest.mark.asyncio
+async def test_erb_docs_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        "render <%= @user.name %> inside your erb view",
+    )
+
+
+@pytest.mark.asyncio
+async def test_nosql_where_op_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(
+        sus_patterns_manager_with_detection, '{"$where": "this.password.length > 0"}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_nosql_ne_null_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(sus_patterns_manager_with_detection, '{"$ne":null}')
+
+
+@pytest.mark.asyncio
+async def test_nosql_legit_value_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        'the mongo filter {"$gt": 5} returns larger values',
+    )

--- a/tests/test_sync/test_preprocessor_encodings.py
+++ b/tests/test_sync/test_preprocessor_encodings.py
@@ -26,11 +26,11 @@ def test_js_unicode_escape_decoded(pp: ContentPreprocessor) -> None:
     assert "<script" in result.lower()
 
 
-def test_sql_block_comment_stripped(pp: ContentPreprocessor) -> None:
+def test_sql_block_comment_retained_not_fused(pp: ContentPreprocessor) -> None:
     payload = "SELE/**/CT password FRO/**/M users"
     result = pp.preprocess(payload)
-    assert "select" in result.lower()
-    assert "from" in result.lower()
+    assert "/**/" in result
+    assert "select" not in result.lower()
 
 
 def test_sql_line_comment_stripped(pp: ContentPreprocessor) -> None:
@@ -94,7 +94,7 @@ def test_decode_unicode_escapes_directly(pp: ContentPreprocessor) -> None:
 
 
 def test_strip_sql_comments_block(pp: ContentPreprocessor) -> None:
-    assert pp._strip_sql_comments("SEL/*x*/ECT") == "SELECT"
+    assert pp._strip_sql_comments("SEL/*x*/ECT") == "SEL/*x*/ECT"
 
 
 def test_strip_sql_comments_line(pp: ContentPreprocessor) -> None:
@@ -146,35 +146,31 @@ def test_unicode_escape_value_error_path(pp: ContentPreprocessor) -> None:
     assert result == "\\u0041"
 
 
-def test_sql_between_token_comment_preserves_word_boundaries(
+def test_sql_between_token_comment_retained(
     pp: ContentPreprocessor,
 ) -> None:
     payload = "WHERE id=1/**/OR/**/x=2"
     result = pp.preprocess(payload)
-    lower = result.lower()
-    assert "1or" not in lower
-    assert "orx" not in lower
-    assert " or " in lower
+    assert "/**/" in result
+    assert "1or" not in result.lower()
 
 
-def test_sql_lowercase_keyword_comment_reconstructs(
+def test_sql_lowercase_keyword_comment_retained(
     pp: ContentPreprocessor,
 ) -> None:
     payload = "sele/**/ct password fro/**/m users"
     result = pp.preprocess(payload)
-    lower = result.lower()
-    assert "select" in lower
-    assert "from" in lower
+    assert "/**/" in result
+    assert "select" not in result.lower()
 
 
-def test_sql_uppercase_keyword_then_lowercase_identifier_no_fusion(
+def test_sql_uppercase_keyword_comment_retained(
     pp: ContentPreprocessor,
 ) -> None:
     payload = "WHERE id=1 OR/**/x=2"
     result = pp.preprocess(payload)
-    lower = result.lower()
-    assert "orx" not in lower
-    assert " or " in lower or lower.endswith(" or") or lower.startswith("or ")
+    assert "/**/" in result
+    assert "orx" not in result.lower()
 
 
 def test_truncate_preserves_tail_content_after_attack_region(


### PR DESCRIPTION
Installs the scoring lever for false-positive reduction — in the "off" position. Behavior is identical to today; this is pure infrastructure for B3.2 (which turns ambiguous-pattern weights down to actually cut false positives).

## What changed
- New `SecurityConfig.detection_threat_score_threshold` field (default **1.0**).
- Per-category weight map `DETECTION_CATEGORY_WEIGHTS` (every category → 1.0) + an empty `DETECTION_PATTERN_WEIGHT_OVERRIDES` map + `_resolve_pattern_weight()`. Each regex threat dict now carries a `weight`.
- `_calculate_threat_score` is now **additive** (sum of matched-pattern weights, capped at 1.0) instead of a flat 1.0.
- `is_threat` is gated: `anomaly >= threshold or any-semantic-threat`.

## Why it's behavior-neutral
Every weight = 1.0 and threshold = 1.0 ⇒ any single regex match gives anomaly ≥ 1.0 ⇒ `is_threat = True`, exactly as before. Semantic-only threats still flag via their presence.

## Verification
- **345 tests pass** (the full detection + sync-mirror + attack-sim suites), zero changes to existing tests — the recall net.
- Harness baseline **unchanged: detection 0.857, fp 0.125** (ratchet green).
- A dedicated test proves the lever works (threshold = 2.0 suppresses a single-pattern match).
- ruff check + format clean; vulture clean; async/sync handlers byte-identical.

## Next (B3.2, separate)
Expand the benign corpus (the pressure test already found Phase B introduced 4 new FP vectors) + lower ambiguous-pattern weights below threshold + surgical tightening → drop fp_rate while the recall ratchet (≥ 0.857) holds.

No API/route changes. `detection_threat_score_threshold` is a new config field; the downstream guard-core-app SecurityConfig catalog will need regen when it next bumps the dependency (separate cross-repo).