### PR TITLE
feat(detection): B3.2 false-positive reduction (fp 0.125 -> 0.0, recall held)

### DIFF
--- a/guard_core/handlers/suspatterns_handler.py
+++ b/guard_core/handlers/suspatterns_handler.py
@@ -75,11 +75,19 @@ CATEGORY_CONTEXT_MAP: dict[str, frozenset[str]] = {
     "code_injection": _CTX_CODE_INJECTION,
 }
 
+_SELECT_FROM_RE = r"(?i)SELECT\s+[\w\s,\*]+\s+FROM\s+[\w\s\._]+"
+_SELECT_STAR_RE = r"(?i)SELECT\s+\*"
+_WHERE_CLAUSE_RE = r'(?i)\bWHERE\s+[\w."]+\s*(?:=|<|>|<=|>=|LIKE|IN)\b'
+
 DETECTION_CATEGORY_WEIGHTS: dict[str, float] = {
     category: 1.0 for category in ALL_DETECTION_CATEGORIES
 }
 
-DETECTION_PATTERN_WEIGHT_OVERRIDES: dict[str, float] = {}
+DETECTION_PATTERN_WEIGHT_OVERRIDES: dict[str, float] = {
+    _SELECT_FROM_RE: 0.5,
+    _SELECT_STAR_RE: 0.5,
+    _WHERE_CLAUSE_RE: 0.5,
+}
 
 
 def _resolve_pattern_weight(pattern: str, category: str) -> float:
@@ -120,7 +128,9 @@ class SusPatternsManager:
         (r"(?:<object[^>]*>[\s\S]*<\/object\s*>)", _CTX_XSS, "xss"),
         (r"(?:<embed[^>]*>[\s\S]*<\/embed\s*>)", _CTX_XSS, "xss"),
         (r"(?:<applet[^>]*>[\s\S]*<\/applet\s*>)", _CTX_XSS, "xss"),
-        (r"(?i)SELECT\s+[\w\s,\*]+\s+FROM\s+[\w\s\._]+", _CTX_SQLI, "sqli"),
+        (_SELECT_FROM_RE, _CTX_SQLI, "sqli"),
+        (_SELECT_STAR_RE, _CTX_SQLI, "sqli"),
+        (_WHERE_CLAUSE_RE, _CTX_SQLI, "sqli"),
         (r"(?i)UNION\s+(?:ALL\s+)?SELECT", _CTX_SQLI, "sqli"),
         (
             r"(?i)('\s*(?:OR|AND)\s*[\(\s]*'?[\d\w]+\s*(?:=|LIKE|<|>|<=|>=)\s*"

--- a/guard_core/handlers/suspatterns_handler.py
+++ b/guard_core/handlers/suspatterns_handler.py
@@ -157,7 +157,7 @@ class SusPatternsManager:
         (r"\w/\*(?!!)[^*]*\*/\w", _CTX_SQLI, "sqli"),
         (r"(?i)(?:OR|AND)\s+'[\w\d]*'='[\w\d]*'?", _CTX_SQLI, "sqli"),
         (
-            r"(?i)(?:^|;)\s*(?:DROP|TRUNCATE|ALTER)\s+(?:TABLE|DATABASE|SCHEMA)\b",
+            r"(?i);\s*(?:DROP|TRUNCATE|ALTER)\s+(?:TABLE|DATABASE|SCHEMA)\b",
             _CTX_SQLI,
             "sqli",
         ),
@@ -166,7 +166,7 @@ class SusPatternsManager:
             _CTX_SQLI,
             "sqli",
         ),
-        (r"(?i)\bORDER\s+BY\s+\d+\b", _CTX_SQLI, "sqli"),
+        (r"(?i)\bORDER\s+BY\s+\d+\s*(?:--|#|;|\)|,|/\*|$)", _CTX_SQLI, "sqli"),
         (r"(?:\.\.\/|\.\.\\)(?:\.\.\/|\.\.\\)+", _CTX_DIR_TRAVERSAL, "dir_traversal"),
         (
             r"(?:/etc/(?:passwd|shadow|group|hosts|motd|issue|mysql/my.cnf|ssh/"
@@ -250,7 +250,13 @@ class SusPatternsManager:
         ),
         (r"(?:\{\s*\$[a-zA-Z]+\s*:\s*(?:\{|\[))", _CTX_NOSQL, "nosql"),
         (
-            r'"\$(?:where|gt|gte|lt|lte|ne|eq|regex|in|nin|all|size|exists|type|mod|options|expr|jsonSchema)"\s*:',
+            r'"\$(?:where|regex|expr|jsonSchema|function|accumulator|type|exists|size)"\s*:',
+            _CTX_NOSQL,
+            "nosql",
+        ),
+        (
+            r'"\$(?:gt|gte|lt|lte|ne|eq|in|nin|all|mod)"'
+            r'\s*:\s*(?:""|null|\{|\[)',
             _CTX_NOSQL,
             "nosql",
         ),
@@ -276,7 +282,12 @@ class SusPatternsManager:
             _CTX_TEMPLATE,
             "template",
         ),
-        (r"<%[=#]?[^%]*%>", _CTX_TEMPLATE, "template"),
+        (
+            r"(?i)<%[=#]?[^%]*(?:system|exec|eval|`|Runtime|IO\.|File\.|Dir\."
+            r"|\d+\s*[-+*/]\s*\d+)[^%]*%>",
+            _CTX_TEMPLATE,
+            "template",
+        ),
         (
             r"\$\{[^}]*(?:@[\w.]+@|\b\w+\s*\(|\d+\s*[*/%+\-]\s*\d+)[^}]*\}",
             _CTX_TEMPLATE,

--- a/guard_core/sync/handlers/suspatterns_handler.py
+++ b/guard_core/sync/handlers/suspatterns_handler.py
@@ -75,11 +75,19 @@ CATEGORY_CONTEXT_MAP: dict[str, frozenset[str]] = {
     "code_injection": _CTX_CODE_INJECTION,
 }
 
+_SELECT_FROM_RE = r"(?i)SELECT\s+[\w\s,\*]+\s+FROM\s+[\w\s\._]+"
+_SELECT_STAR_RE = r"(?i)SELECT\s+\*"
+_WHERE_CLAUSE_RE = r'(?i)\bWHERE\s+[\w."]+\s*(?:=|<|>|<=|>=|LIKE|IN)\b'
+
 DETECTION_CATEGORY_WEIGHTS: dict[str, float] = {
     category: 1.0 for category in ALL_DETECTION_CATEGORIES
 }
 
-DETECTION_PATTERN_WEIGHT_OVERRIDES: dict[str, float] = {}
+DETECTION_PATTERN_WEIGHT_OVERRIDES: dict[str, float] = {
+    _SELECT_FROM_RE: 0.5,
+    _SELECT_STAR_RE: 0.5,
+    _WHERE_CLAUSE_RE: 0.5,
+}
 
 
 def _resolve_pattern_weight(pattern: str, category: str) -> float:
@@ -120,7 +128,9 @@ class SusPatternsManager:
         (r"(?:<object[^>]*>[\s\S]*<\/object\s*>)", _CTX_XSS, "xss"),
         (r"(?:<embed[^>]*>[\s\S]*<\/embed\s*>)", _CTX_XSS, "xss"),
         (r"(?:<applet[^>]*>[\s\S]*<\/applet\s*>)", _CTX_XSS, "xss"),
-        (r"(?i)SELECT\s+[\w\s,\*]+\s+FROM\s+[\w\s\._]+", _CTX_SQLI, "sqli"),
+        (_SELECT_FROM_RE, _CTX_SQLI, "sqli"),
+        (_SELECT_STAR_RE, _CTX_SQLI, "sqli"),
+        (_WHERE_CLAUSE_RE, _CTX_SQLI, "sqli"),
         (r"(?i)UNION\s+(?:ALL\s+)?SELECT", _CTX_SQLI, "sqli"),
         (
             r"(?i)('\s*(?:OR|AND)\s*[\(\s]*'?[\d\w]+\s*(?:=|LIKE|<|>|<=|>=)\s*"

--- a/guard_core/sync/handlers/suspatterns_handler.py
+++ b/guard_core/sync/handlers/suspatterns_handler.py
@@ -157,7 +157,7 @@ class SusPatternsManager:
         (r"\w/\*(?!!)[^*]*\*/\w", _CTX_SQLI, "sqli"),
         (r"(?i)(?:OR|AND)\s+'[\w\d]*'='[\w\d]*'?", _CTX_SQLI, "sqli"),
         (
-            r"(?i)(?:^|;)\s*(?:DROP|TRUNCATE|ALTER)\s+(?:TABLE|DATABASE|SCHEMA)\b",
+            r"(?i);\s*(?:DROP|TRUNCATE|ALTER)\s+(?:TABLE|DATABASE|SCHEMA)\b",
             _CTX_SQLI,
             "sqli",
         ),
@@ -166,7 +166,7 @@ class SusPatternsManager:
             _CTX_SQLI,
             "sqli",
         ),
-        (r"(?i)\bORDER\s+BY\s+\d+\b", _CTX_SQLI, "sqli"),
+        (r"(?i)\bORDER\s+BY\s+\d+\s*(?:--|#|;|\)|,|/\*|$)", _CTX_SQLI, "sqli"),
         (r"(?:\.\.\/|\.\.\\)(?:\.\.\/|\.\.\\)+", _CTX_DIR_TRAVERSAL, "dir_traversal"),
         (
             r"(?:/etc/(?:passwd|shadow|group|hosts|motd|issue|mysql/my.cnf|ssh/"
@@ -250,7 +250,13 @@ class SusPatternsManager:
         ),
         (r"(?:\{\s*\$[a-zA-Z]+\s*:\s*(?:\{|\[))", _CTX_NOSQL, "nosql"),
         (
-            r'"\$(?:where|gt|gte|lt|lte|ne|eq|regex|in|nin|all|size|exists|type|mod|options|expr|jsonSchema)"\s*:',
+            r'"\$(?:where|regex|expr|jsonSchema|function|accumulator|type|exists|size)"\s*:',
+            _CTX_NOSQL,
+            "nosql",
+        ),
+        (
+            r'"\$(?:gt|gte|lt|lte|ne|eq|in|nin|all|mod)"'
+            r'\s*:\s*(?:""|null|\{|\[)',
             _CTX_NOSQL,
             "nosql",
         ),
@@ -276,7 +282,12 @@ class SusPatternsManager:
             _CTX_TEMPLATE,
             "template",
         ),
-        (r"<%[=#]?[^%]*%>", _CTX_TEMPLATE, "template"),
+        (
+            r"(?i)<%[=#]?[^%]*(?:system|exec|eval|`|Runtime|IO\.|File\.|Dir\."
+            r"|\d+\s*[-+*/]\s*\d+)[^%]*%>",
+            _CTX_TEMPLATE,
+            "template",
+        ),
         (
             r"\$\{[^}]*(?:@[\w.]+@|\b\w+\s*\(|\d+\s*[*/%+\-]\s*\d+)[^}]*\}",
             _CTX_TEMPLATE,

--- a/tests/attack_simulation/baseline.json
+++ b/tests/attack_simulation/baseline.json
@@ -1,4 +1,4 @@
 {
   "detection_rate": 0.8568421052631578,
-  "fp_rate": 0.125
+  "fp_rate": 0.0
 }

--- a/tests/attack_simulation/corpus/benign/legit_code_comments.txt
+++ b/tests/attack_simulation/corpus/benign/legit_code_comments.txt
@@ -1,0 +1,7 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+color: red; /* main theme */ font-size: 14px
+const total = price /* legacy adjustment */ + tax
+avoid modifying Object.prototype or __proto__ in your code
+call the helper to launch the app when ready
+the config sets a = b in the default section

--- a/tests/attack_simulation/corpus/benign/legit_json_mongo.txt
+++ b/tests/attack_simulation/corpus/benign/legit_json_mongo.txt
@@ -1,0 +1,9 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+{"price":"$25","name":"coffee","size":"large"}
+{"filter":{"$gt":5},"limit":20}
+{"age":{"$gte":18},"active":true}
+{"sort":{"created":-1},"page":2}
+{"type":"string","name":"coffee","price":"$25"}
+{"user":"renzo","role":"admin","tier":"team"}
+{"range":{"$lt":100,"$gt":10}}

--- a/tests/attack_simulation/corpus/benign/legit_templates_docs.txt
+++ b/tests/attack_simulation/corpus/benign/legit_templates_docs.txt
@@ -1,0 +1,7 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+render <%= @user.name %> inside your erb view
+the template shows <%= product.title %> at the top
+use ${user.displayName} for the greeting in the layout
+set the variable with export PATH=${HOME}/bin
+the docs mention {{ page.title }} as a placeholder

--- a/tests/attack_simulation/corpus/benign/legit_urls_params.txt
+++ b/tests/attack_simulation/corpus/benign/legit_urls_params.txt
@@ -1,0 +1,7 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+search?q=hello%20world%20coffee&sort=relevance
+/api/v1/orders/history?from=2026-01-01&to=2026-06-30
+/docs/getting-started/installation#configuration
+filter?category=books&order=title&direction=asc
+the price range is $10 to $50 for the order

--- a/tests/attack_simulation/corpus/benign/prose_shell_extended.txt
+++ b/tests/attack_simulation/corpus/benign/prose_shell_extended.txt
@@ -1,0 +1,10 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+first do this; then list the remaining steps for the team
+run ls -la in your notes to remember the layout
+to listen on the port use nc as described in the manual
+please remove the old files and copy the summary over
+let me cat the photos of my pet and the dog she adopted
+evaluate the plan before you execute the next phase
+the system will ping you when the export is ready
+we ship via socat logistics on tuesdays and fridays

--- a/tests/attack_simulation/corpus/benign/prose_sql_extended.txt
+++ b/tests/attack_simulation/corpus/benign/prose_sql_extended.txt
@@ -1,0 +1,12 @@
+# source: project-authored false-positive probes
+# license: guard-core (project)
+I'll select a few items from the catalog for you
+we will select candidates from the applicant pool where appropriate
+please sort the results, order by 1 ascending then by name
+drop table 7 is reserved for the wedding party tonight
+the union meeting is scheduled; bring your badge and lunch
+we should update users about the new schedule next week
+let me select the best photo from the album for the cover
+the order form asks you to select a size from the dropdown
+group discounts apply when you order by the dozen
+insert the card into the reader and wait for the beep

--- a/tests/test_sus_patterns/test_fp_reduction.py
+++ b/tests/test_sus_patterns/test_fp_reduction.py
@@ -1,0 +1,34 @@
+import pytest
+
+
+async def _flagged(manager, payload: str) -> bool:
+    result = await manager.detect(payload, "127.0.0.1", context="unknown")
+    return result["is_threat"]
+
+
+@pytest.mark.asyncio
+async def test_select_star_still_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(sus_patterns_manager_with_detection, "SELECT * FROM users")
+
+
+@pytest.mark.asyncio
+async def test_select_where_still_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(
+        sus_patterns_manager_with_detection, "SELECT password FROM users WHERE id=1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_select_prose_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        "I'll select a few items from the catalog for you",
+    )
+
+
+@pytest.mark.asyncio
+async def test_select_candidates_prose_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        "we will select candidates from the applicant pool",
+    )

--- a/tests/test_sus_patterns/test_fp_reduction.py
+++ b/tests/test_sus_patterns/test_fp_reduction.py
@@ -32,3 +32,62 @@ async def test_select_candidates_prose_not_flagged(sus_patterns_manager_with_det
         sus_patterns_manager_with_detection,
         "we will select candidates from the applicant pool",
     )
+
+
+@pytest.mark.asyncio
+async def test_order_by_attack_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(sus_patterns_manager_with_detection, "1' ORDER BY 1--")
+
+
+@pytest.mark.asyncio
+async def test_order_by_prose_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        "sort the results, order by 1 ascending then by name",
+    )
+
+
+@pytest.mark.asyncio
+async def test_ddl_attack_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(sus_patterns_manager_with_detection, "'; DROP TABLE users;--")
+
+
+@pytest.mark.asyncio
+async def test_ddl_prose_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        "drop table 7 is reserved for the wedding party",
+    )
+
+
+@pytest.mark.asyncio
+async def test_erb_attack_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(sus_patterns_manager_with_detection, "<%= 7*7 %>")
+
+
+@pytest.mark.asyncio
+async def test_erb_docs_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        "render <%= @user.name %> inside your erb view",
+    )
+
+
+@pytest.mark.asyncio
+async def test_nosql_where_op_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(
+        sus_patterns_manager_with_detection, '{"$where": "this.password.length > 0"}'
+    )
+
+
+@pytest.mark.asyncio
+async def test_nosql_ne_null_flagged(sus_patterns_manager_with_detection):
+    assert await _flagged(sus_patterns_manager_with_detection, '{"$ne":null}')
+
+
+@pytest.mark.asyncio
+async def test_nosql_legit_value_not_flagged(sus_patterns_manager_with_detection):
+    assert not await _flagged(
+        sus_patterns_manager_with_detection,
+        'the mongo filter {"$gt": 5} returns larger values',
+    )


### PR DESCRIPTION
Stacks on #36 (B3.1). Closes out the B3 precision arc. Retarget to master once #36 merges.

## Result (harness, expanded 56-sample benign corpus)
- **fp_rate: 0.125 -> 0.000** — every benign category now clean, including the pre-existing `SELECT…FROM`-in-prose (0.67) and the 4 FP vectors Phase B introduced.
- **detection_rate: 0.8568 (held exactly)** — zero recall loss; the ratchet floor was the guardrail.

## How
- **`SELECT…FROM` corroboration scoring:** its weight drops to 0.5 (via B3.1's override map); two new 0.5-weight signals (`SELECT *`, a `WHERE <op>` clause) push real SQLi back over the 1.0 threshold. `SELECT * FROM users` and `… WHERE id=1` still flag; "select items from the catalog" no longer does.
- **Surgical tightening:** ORDER BY requires a terminator; DDL requires the `;` separator; ERB requires dangerous content (not `@user.name`); NoSQL split into always-dangerous operators (`$where`/`$regex`/`$type`/`$exists`/…) vs comparison operators gated on injection-shaped values (`""`/`null`/`{`/`[`), so `{"$gt": 5}` is clean while `{"$ne":null}`/`{"$where":…}` still flag.
- **Expanded benign corpus** (+40 realistic samples: keyword-bearing prose, legit Mongo/JSON, template docs, code comments, URL params) — the FP measurement instrument.

## Verification
358 tests pass (full detection + sync-mirror + attack-sim ratchet). 13 new FP-reduction unit tests pin each fix in both directions (attack flagged, benign near-miss clean). ruff/format/vulture clean; async/sync byte-identical.

## Note
One over-reach caught mid-work by the ratchet: value-gating `$type` dropped the `{"$type":"string"}` seed (recall 0.92->0.68); fixed by moving diagnostic operators to the always-dangerous group. Recall restored to 0.8568 exactly. No API/route changes.