### PR TITLE
ci: test the PR's own code, and fix the two failures that hid behind it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
       - 'pytest.ini'
       - 'reqs.pip'
       - 'tests/**'
-  pull_request_target:
+  pull_request:
     branches:
       - master
     paths:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -11,8 +11,8 @@ jobs:
     steps:
     - uses: actions/first-interaction@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        issue-message: |
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        issue_message: |
             Thanks for opening your first issue on **guard-core**!
 
             To help us triage quickly, please make sure your report includes:
@@ -28,7 +28,7 @@ jobs:
             - **Security vulnerability?** Do **not** open a public issue — please follow [SECURITY.md](../blob/master/SECURITY.md) and use GitHub's private vulnerability reporting.
 
             Thanks again — a maintainer will be with you soon.
-        pr-message: |
+        pr_message: |
             Thanks for opening your first pull request on **guard-core**!
 
             Quick checklist before review (most of these are enforced by CI, but worth a glance):

--- a/tests/test_handler_initializer_lazy_init.py
+++ b/tests/test_handler_initializer_lazy_init.py
@@ -84,7 +84,7 @@ async def test_lazy_init_returns_fast_with_slow_background() -> None:  # async-o
         await initializer.initialize_redis_handlers()
         elapsed = time.perf_counter() - start
 
-        assert elapsed < 0.1
+        assert elapsed < 0.5
         assert initializer._lazy_init_task is not None
         assert initializer._lazy_init_task.done() is False
         initializer._lazy_init_task.cancel()


### PR DESCRIPTION
Three CI-correctness fixes. The first explains why the other two went unnoticed.

## 1. CI never tested the pull request

`ci.yml` triggered on `pull_request_target` with a bare `actions/checkout@v7` and no `ref:`, so **every run tested master instead of the change**. Proof, from this very PR before the fix — my branch has `assert elapsed < 0.5`, and the runner executed:

```
test (3.14)  Run tests  >           assert elapsed < 0.1
test (3.14)  Run tests  E           assert 0.14268466699996907 < 0.1
```

That is master's line, not mine. So PR checks have been reporting on the base branch all along — which is exactly how #45 went green and then broke master on merge.

Switched to `pull_request`. `labeler.yml` and `greetings.yml` keep `pull_request_target`: they need write access and never check out PR code. Adding `ref: github.event.pull_request.head.sha` to `pull_request_target` was rejected deliberately — it would execute untrusted fork code with `SLACK_TOKEN`, `IPINFO_TOKEN` and a write-scoped token.

Trade-off: fork PRs get no secrets, so the Slack steps and `IPINFO_TOKEN` go empty there. Same-repo PRs are unaffected.

## 2. The flaky timing assertion

```
FAILED tests/test_handler_initializer_lazy_init.py::test_lazy_init_returns_fast_with_slow_background - assert 0.1625094430000047 < 0.1
```

`0.1s` was the tightest timing bound in the suite by 5x — every sibling allows `0.5s` or `1.0s`, including one 26 lines below it. Raised to `0.5s`. The background work sleeps 5s, so it still fails loudly if the call ever awaits it, and `assert initializer._lazy_init_task.done() is False` on the next line proves the non-blocking property without touching the clock.

Not a regression from #45 — that test patches `suspatterns_handler` wholesale and never reaches the new pattern.

## 3. Greetings never ran

`actions/first-interaction@v3` renamed its inputs to `issue_message` / `pr_message` / `repo_token`; the workflow still passed v2 kebab-case names, so the action received nothing and failed on every PR with `Input required and not supplied: issue_message`.

## Verification

Full suite **4148 passed**, 100% line and branch coverage; the lazy-init file passes 8/8 consecutive runs at ~0.03s per call, 16x under the new bound; `make check-sync` up to date.

Note this PR's own checks still run under master's `pull_request_target` config, so they will keep testing master and reporting the `0.1` failure until this is merged. The fix cannot validate itself.