### PR TITLE
feat(detection): tunable anomaly cooldown and min-samples (v3.11.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,20 @@ ___
 v3.11.1 (2026-08-10)
 -------------------
 
-Azure IP-range fetch failed every refresh for slow egress or region-variant Microsoft pages (v3.11.1)
------------------------------------------------------------------------------------------------------
+Azure IP-range fetch failed on slow egress and anomaly detection over-fired on low-traffic apps (v3.11.1)
+---------------------------------------------------------------------------------------------------------
 
 ### Fixed
 
 - `fetch_azure_ip_ranges` was the only cloud provider fetched by scraping Microsoft's HTML download page with a regex and then downloading the dated ServiceTags JSON under a hard 10-second total timeout. The other five providers hit direct JSON endpoints with small payloads, so only Azure produced a recurring `Failed to fetch Azure IP ranges` error, on every refresh, for deployments whose egress to `download.microsoft.com` could not complete the 4.7 MB download within 10 seconds, or whose region received a details page whose markup the regex did not match. The JSON download timeout is raised to 30 seconds (the other five providers keep their 10-second direct-endpoint timeout), the download is retried up to three times with a 2-second backoff on transient errors, and URL discovery now falls back to a bare-URL search constrained to `ServiceTags` files when the href-wrapped form is not found, covering pages that embed the link in JavaScript or data attributes without matching unrelated `.json` links on the page; both the href and fallback forms preserve a trailing query string. A failed fetch still resolves to an empty range set, so it cannot cause false blocking of legitimate Azure IPs; the change is about reliability and log noise, not enforcement.
+
+### Added
+
+- Two new `SecurityConfig` fields make the statistical-anomaly detector tunable: `detection_anomaly_emission_cooldown` (default `60.0`, bounds 1.0 to 3600.0) sets the minimum seconds between anomaly events for the same pattern, and `detection_min_samples_for_anomaly` (default `30`, bounds 10 to 1000) sets the minimum samples recorded for a pattern before statistical-anomaly detection engages. `anomaly_emission_cooldown` was already a `PerformanceMonitor` constructor parameter but was never wired from `SecurityConfig`, so it was fixed at 60 seconds; the sample floor was a hardcoded `len(recent_times) < 10` check. Both are now passed from config in `suspatterns_handler._apply_enhanced_config`. Raise either to reduce noise and false fires on low-traffic apps.
+
+### Behaviour changes
+
+- The default minimum-samples floor for statistical-anomaly detection rises from 10 to 30. A pattern with fewer than 30 recorded samples no longer emits `pattern_anomaly_statistical_anomaly` events until 30 samples accumulate. This is the intended effect: the old 10-sample floor combined with high variance on low-traffic apps produced a flood of false anomalies. Operators who relied on the old floor can restore it with `detection_min_samples_for_anomaly=10`.
 
 ___
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ ENV PATH="/app/.venv/bin:$PATH"
 
 COPY guard_core/ /app/guard_core/
 COPY tests/ /app/tests/
+COPY scripts/ /app/scripts/
 COPY docs/ /app/docs/
 
 RUN mkdir -p /app/data/ipinfo

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -13,12 +13,20 @@ ___
 v3.11.1 (2026-08-10)
 -------------------
 
-Azure IP-range fetch failed every refresh for slow egress or region-variant Microsoft pages (v3.11.1)
------------------------------------------------------------------------------------------------------
+Azure IP-range fetch failed on slow egress and anomaly detection over-fired on low-traffic apps (v3.11.1)
+---------------------------------------------------------------------------------------------------------
 
 ### Fixed
 
 - `fetch_azure_ip_ranges` was the only cloud provider fetched by scraping Microsoft's HTML download page with a regex and then downloading the dated ServiceTags JSON under a hard 10-second total timeout. The other five providers hit direct JSON endpoints with small payloads, so only Azure produced a recurring `Failed to fetch Azure IP ranges` error, on every refresh, for deployments whose egress to `download.microsoft.com` could not complete the 4.7 MB download within 10 seconds, or whose region received a details page whose markup the regex did not match. The JSON download timeout is raised to 30 seconds (the other five providers keep their 10-second direct-endpoint timeout), the download is retried up to three times with a 2-second backoff on transient errors, and URL discovery now falls back to a bare-URL search constrained to `ServiceTags` files when the href-wrapped form is not found, covering pages that embed the link in JavaScript or data attributes without matching unrelated `.json` links on the page; both the href and fallback forms preserve a trailing query string. A failed fetch still resolves to an empty range set, so it cannot cause false blocking of legitimate Azure IPs; the change is about reliability and log noise, not enforcement.
+
+### Added
+
+- Two new `SecurityConfig` fields make the statistical-anomaly detector tunable: `detection_anomaly_emission_cooldown` (default `60.0`, bounds 1.0 to 3600.0) sets the minimum seconds between anomaly events for the same pattern, and `detection_min_samples_for_anomaly` (default `30`, bounds 10 to 1000) sets the minimum samples recorded for a pattern before statistical-anomaly detection engages. `anomaly_emission_cooldown` was already a `PerformanceMonitor` constructor parameter but was never wired from `SecurityConfig`, so it was fixed at 60 seconds; the sample floor was a hardcoded `len(recent_times) < 10` check. Both are now passed from config in `suspatterns_handler._apply_enhanced_config`. Raise either to reduce noise and false fires on low-traffic apps.
+
+### Behaviour changes
+
+- The default minimum-samples floor for statistical-anomaly detection rises from 10 to 30. A pattern with fewer than 30 recorded samples no longer emits `pattern_anomaly_statistical_anomaly` events until 30 samples accumulate. This is the intended effect: the old 10-sample floor combined with high variance on low-traffic apps produced a flood of false anomalies. Operators who relied on the old floor can restore it with `detection_min_samples_for_anomaly=10`.
 
 ___
 

--- a/guard_core/detection_engine/monitor.py
+++ b/guard_core/detection_engine/monitor.py
@@ -38,6 +38,7 @@ class PerformanceMonitor:
         history_size: int = 1000,
         max_tracked_patterns: int = 1000,
         anomaly_emission_cooldown: float = 60.0,
+        min_samples_for_anomaly: int = 30,
     ):
         self.anomaly_threshold = max(1.0, min(10.0, float(anomaly_threshold)))
         self.slow_pattern_threshold = max(
@@ -48,6 +49,7 @@ class PerformanceMonitor:
         self.anomaly_emission_cooldown = max(
             1.0, min(3600.0, float(anomaly_emission_cooldown))
         )
+        self.min_samples_for_anomaly = max(10, min(1000, int(min_samples_for_anomaly)))
 
         self.pattern_stats: dict[str, PatternStats] = {}
         self.recent_metrics: deque[PerformanceMetric] = deque(maxlen=history_size)
@@ -134,7 +136,7 @@ class PerformanceMonitor:
         self, metric: PerformanceMetric
     ) -> dict[str, Any] | None:
         stats = self.pattern_stats.get(metric.pattern)
-        if not stats or len(stats.recent_times) < 10:
+        if not stats or len(stats.recent_times) < self.min_samples_for_anomaly:
             return None
 
         recent_times = list(stats.recent_times)

--- a/guard_core/handlers/suspatterns_handler.py
+++ b/guard_core/handlers/suspatterns_handler.py
@@ -489,6 +489,8 @@ class SusPatternsManager:
             slow_pattern_threshold=config.detection_slow_pattern_threshold,
             history_size=config.detection_monitor_history_size,
             max_tracked_patterns=config.detection_max_tracked_patterns,
+            anomaly_emission_cooldown=config.detection_anomaly_emission_cooldown,
+            min_samples_for_anomaly=config.detection_min_samples_for_anomaly,
         )
         instance._semantic_threshold = config.detection_semantic_threshold
         instance._threat_score_threshold = config.detection_threat_score_threshold

--- a/guard_core/models.py
+++ b/guard_core/models.py
@@ -711,6 +711,26 @@ class SecurityConfig(BaseModel):
         le=5000,
     )
 
+    detection_anomaly_emission_cooldown: float = Field(
+        default=60.0,
+        description=(
+            "Min seconds between anomaly events for the same pattern. "
+            "Raise to reduce noise on low-traffic apps."
+        ),
+        ge=1.0,
+        le=3600.0,
+    )
+
+    detection_min_samples_for_anomaly: int = Field(
+        default=30,
+        description=(
+            "Minimum samples recorded for a pattern before statistical-anomaly "
+            "detection engages. Raise to reduce false fires on low-traffic apps."
+        ),
+        ge=10,
+        le=1000,
+    )
+
     detection_threat_score_threshold: float = Field(
         default=1.0,
         description="Anomaly score required to flag a request as a threat",

--- a/guard_core/sync/detection_engine/monitor.py
+++ b/guard_core/sync/detection_engine/monitor.py
@@ -38,6 +38,7 @@ class PerformanceMonitor:
         history_size: int = 1000,
         max_tracked_patterns: int = 1000,
         anomaly_emission_cooldown: float = 60.0,
+        min_samples_for_anomaly: int = 30,
     ):
         self.anomaly_threshold = max(1.0, min(10.0, float(anomaly_threshold)))
         self.slow_pattern_threshold = max(
@@ -48,6 +49,7 @@ class PerformanceMonitor:
         self.anomaly_emission_cooldown = max(
             1.0, min(3600.0, float(anomaly_emission_cooldown))
         )
+        self.min_samples_for_anomaly = max(10, min(1000, int(min_samples_for_anomaly)))
 
         self.pattern_stats: dict[str, PatternStats] = {}
         self.recent_metrics: deque[PerformanceMetric] = deque(maxlen=history_size)
@@ -134,7 +136,7 @@ class PerformanceMonitor:
         self, metric: PerformanceMetric
     ) -> dict[str, Any] | None:
         stats = self.pattern_stats.get(metric.pattern)
-        if not stats or len(stats.recent_times) < 10:
+        if not stats or len(stats.recent_times) < self.min_samples_for_anomaly:
             return None
 
         recent_times = list(stats.recent_times)

--- a/guard_core/sync/handlers/suspatterns_handler.py
+++ b/guard_core/sync/handlers/suspatterns_handler.py
@@ -488,6 +488,8 @@ class SusPatternsManager:
             slow_pattern_threshold=config.detection_slow_pattern_threshold,
             history_size=config.detection_monitor_history_size,
             max_tracked_patterns=config.detection_max_tracked_patterns,
+            anomaly_emission_cooldown=config.detection_anomaly_emission_cooldown,
+            min_samples_for_anomaly=config.detection_min_samples_for_anomaly,
         )
         instance._semantic_threshold = config.detection_semantic_threshold
         instance._threat_score_threshold = config.detection_threat_score_threshold

--- a/tests/test_sus_patterns/test_anomaly_scoring.py
+++ b/tests/test_sus_patterns/test_anomaly_scoring.py
@@ -17,6 +17,35 @@ def test_threshold_field_default_and_bounds() -> None:
         SecurityConfig(detection_threat_score_threshold=-1.0)
 
 
+def test_anomaly_emission_cooldown_default_and_bounds() -> None:
+    assert SecurityConfig().detection_anomaly_emission_cooldown == 60.0
+    raised = SecurityConfig(detection_anomaly_emission_cooldown=300)
+    assert raised.detection_anomaly_emission_cooldown == 300
+    with pytest.raises(ValidationError):
+        SecurityConfig(detection_anomaly_emission_cooldown=0.5)
+    with pytest.raises(ValidationError):
+        SecurityConfig(detection_anomaly_emission_cooldown=4000.0)
+
+
+def test_min_samples_for_anomaly_default_and_bounds() -> None:
+    assert SecurityConfig().detection_min_samples_for_anomaly == 30
+    raised = SecurityConfig(detection_min_samples_for_anomaly=50)
+    assert raised.detection_min_samples_for_anomaly == 50
+    with pytest.raises(ValidationError):
+        SecurityConfig(detection_min_samples_for_anomaly=5)
+    with pytest.raises(ValidationError):
+        SecurityConfig(detection_min_samples_for_anomaly=2000)
+
+
+def test_new_detection_fields_round_trip() -> None:
+    config = SecurityConfig(
+        detection_anomaly_emission_cooldown=300,
+        detection_min_samples_for_anomaly=50,
+    )
+    assert config.detection_anomaly_emission_cooldown == 300
+    assert config.detection_min_samples_for_anomaly == 50
+
+
 def test_resolve_weight_defaults_to_category_one() -> None:
     assert _resolve_pattern_weight(r"some-pattern", "sqli") == 1.0
     assert DETECTION_CATEGORY_WEIGHTS["sqli"] == 1.0

--- a/tests/test_sus_patterns/test_monitor.py
+++ b/tests/test_sus_patterns/test_monitor.py
@@ -19,6 +19,7 @@ def test_initialization() -> None:
     assert monitor.history_size == 1000
     assert monitor.max_tracked_patterns == 1000
     assert monitor.anomaly_emission_cooldown == 60.0
+    assert monitor.min_samples_for_anomaly == 30
     assert len(monitor.pattern_stats) == 0
     assert len(monitor.recent_metrics) == 0
     assert len(monitor.anomaly_callbacks) == 0
@@ -29,12 +30,14 @@ def test_initialization() -> None:
         history_size=500,
         max_tracked_patterns=200,
         anomaly_emission_cooldown=30.0,
+        min_samples_for_anomaly=50,
     )
     assert monitor.anomaly_threshold == 5.0
     assert monitor.slow_pattern_threshold == 0.5
     assert monitor.history_size == 500
     assert monitor.max_tracked_patterns == 200
     assert monitor.anomaly_emission_cooldown == 30.0
+    assert monitor.min_samples_for_anomaly == 50
 
 
 def test_initialization_bounds() -> None:
@@ -44,12 +47,14 @@ def test_initialization_bounds() -> None:
         history_size=50,
         max_tracked_patterns=50,
         anomaly_emission_cooldown=0.1,
+        min_samples_for_anomaly=1,
     )
     assert monitor.anomaly_threshold == 1.0
     assert monitor.slow_pattern_threshold == 0.01
     assert monitor.history_size == 100
     assert monitor.max_tracked_patterns == 100
     assert monitor.anomaly_emission_cooldown == 1.0
+    assert monitor.min_samples_for_anomaly == 10
 
     monitor = PerformanceMonitor(
         anomaly_threshold=20.0,
@@ -57,12 +62,14 @@ def test_initialization_bounds() -> None:
         history_size=20000,
         max_tracked_patterns=10000,
         anomaly_emission_cooldown=10000.0,
+        min_samples_for_anomaly=5000,
     )
     assert monitor.anomaly_threshold == 10.0
     assert monitor.slow_pattern_threshold == 10.0
     assert monitor.history_size == 10000
     assert monitor.max_tracked_patterns == 5000
     assert monitor.anomaly_emission_cooldown == 3600.0
+    assert monitor.min_samples_for_anomaly == 1000
 
 
 @pytest.mark.asyncio
@@ -165,7 +172,7 @@ async def test_check_anomalies_statistical() -> None:
     monitor.register_anomaly_callback(anomaly_callback)
 
     pattern = "stat_pattern"
-    for _ in range(20):
+    for _ in range(35):
         await monitor.record_metric(
             pattern=pattern,
             execution_time=0.01,
@@ -222,7 +229,7 @@ async def test_statistical_anomaly_zero_std_dev() -> None:
     monitor.register_anomaly_callback(anomaly_callback)
 
     pattern = "zero_std_pattern"
-    for _ in range(15):
+    for _ in range(35):
         await monitor.record_metric(
             pattern=pattern,
             execution_time=0.01,
@@ -273,6 +280,17 @@ async def test_statistical_anomaly_within_threshold() -> None:
         0.010,
         0.011,
         0.010,
+        0.009,
+        0.010,
+        0.011,
+        0.012,
+        0.009,
+        0.010,
+        0.011,
+        0.010,
+        0.009,
+        0.010,
+        0.011,
         0.009,
         0.010,
         0.011,
@@ -795,7 +813,7 @@ def test_statistical_anomaly_ignores_faster_than_average_execution() -> None:
 
     pattern = "fast_regression_pattern"
     stats = PatternStats(pattern=pattern)
-    stats.recent_times = deque([0.1] * 19 + [0.001], maxlen=100)
+    stats.recent_times = deque([0.1] * 30 + [0.001], maxlen=100)
     monitor.pattern_stats[pattern] = stats
 
     metric = PerformanceMetric(
@@ -817,7 +835,7 @@ def test_statistical_anomaly_detects_slower_than_average_execution() -> None:
 
     pattern = "slow_regression_pattern"
     stats = PatternStats(pattern=pattern)
-    stats.recent_times = deque([0.001] * 19 + [0.1], maxlen=100)
+    stats.recent_times = deque([0.001] * 30 + [0.1], maxlen=100)
     monitor.pattern_stats[pattern] = stats
 
     metric = PerformanceMetric(
@@ -848,7 +866,7 @@ async def test_check_anomalies_statistical_ignores_fast_execution() -> None:
     monitor.register_anomaly_callback(anomaly_callback)
 
     pattern = "fast_stat_pattern"
-    for _ in range(20):
+    for _ in range(35):
         await monitor.record_metric(
             pattern=pattern,
             execution_time=0.01,
@@ -1001,3 +1019,112 @@ async def test_cooldown_state_does_not_survive_max_tracked_patterns_eviction() -
 async def test_reserve_anomaly_emission_allows_untracked_pattern() -> None:
     monitor = PerformanceMonitor()
     assert await monitor._reserve_anomaly_emission("never_recorded") is True
+
+
+@pytest.mark.asyncio
+async def test_min_samples_for_anomaly_suppresses_below_floor() -> None:
+    monitor = PerformanceMonitor(
+        anomaly_threshold=2.0,
+        slow_pattern_threshold=1.0,
+        min_samples_for_anomaly=20,
+    )
+
+    anomalies_detected = []
+
+    def anomaly_callback(anomaly: dict[str, Any]) -> None:
+        anomalies_detected.append(anomaly)  # pragma: no cover
+
+    monitor.register_anomaly_callback(anomaly_callback)
+
+    pattern = "floor_pattern"
+    for _ in range(18):
+        await monitor.record_metric(
+            pattern=pattern,
+            execution_time=0.01,
+            content_length=100,
+            matched=False,
+        )
+
+    await monitor.record_metric(
+        pattern=pattern,
+        execution_time=0.5,
+        content_length=100,
+        matched=False,
+    )
+
+    assert len(anomalies_detected) == 0
+
+
+@pytest.mark.asyncio
+async def test_min_samples_for_anomaly_fires_above_floor() -> None:
+    monitor = PerformanceMonitor(anomaly_threshold=2.0, min_samples_for_anomaly=20)
+
+    anomalies_detected = []
+
+    def anomaly_callback(anomaly: dict[str, Any]) -> None:
+        anomalies_detected.append(anomaly)
+
+    monitor.register_anomaly_callback(anomaly_callback)
+
+    pattern = "above_floor_pattern"
+    for _ in range(20):
+        await monitor.record_metric(
+            pattern=pattern,
+            execution_time=0.01,
+            content_length=100,
+            matched=False,
+        )
+
+    anomalies_detected.clear()
+
+    await monitor.record_metric(
+        pattern=pattern,
+        execution_time=0.5,
+        content_length=100,
+        matched=False,
+    )
+
+    statistical = [a for a in anomalies_detected if a["type"] == "statistical_anomaly"]
+    assert len(statistical) == 1
+    assert statistical[0]["z_score"] > 2.0
+
+
+@pytest.mark.asyncio
+async def test_cooldown_is_configurable_via_constructor() -> None:
+    monitor = PerformanceMonitor(
+        slow_pattern_threshold=0.05, anomaly_emission_cooldown=5.0
+    )
+    agent_handler = MagicMock()
+    agent_handler.send_event = AsyncMock()
+
+    clock = {"now": 1000.0}
+    with patch("time.monotonic", side_effect=lambda: clock["now"]):
+        await monitor.record_metric(
+            pattern="stall_pattern",
+            execution_time=0.5,
+            content_length=100,
+            matched=False,
+            agent_handler=agent_handler,
+        )
+        assert agent_handler.send_event.call_count == 1
+
+        clock["now"] += 2.0
+        await monitor.record_metric(
+            pattern="stall_pattern",
+            execution_time=0.5,
+            content_length=100,
+            matched=False,
+            agent_handler=agent_handler,
+        )
+        assert agent_handler.send_event.call_count == 1
+
+        clock["now"] += 5.0
+        await monitor.record_metric(
+            pattern="stall_pattern",
+            execution_time=0.5,
+            content_length=100,
+            matched=False,
+            agent_handler=agent_handler,
+        )
+
+    assert agent_handler.send_event.call_count == 2

--- a/tests/test_sus_patterns/test_sus_patterns.py
+++ b/tests/test_sus_patterns/test_sus_patterns.py
@@ -230,6 +230,8 @@ async def test_init_with_config() -> None:
     config.detection_slow_pattern_threshold = 0.2
     config.detection_monitor_history_size = 100
     config.detection_semantic_threshold = 0.8
+    config.detection_anomaly_emission_cooldown = 45.0
+    config.detection_min_samples_for_anomaly = 25
 
     SusPatternsManager._instance = None
     manager = SusPatternsManager(config)
@@ -243,6 +245,8 @@ async def test_init_with_config() -> None:
     assert manager._performance_monitor is not None
     assert manager._performance_monitor.anomaly_threshold == 2.5
     assert manager._performance_monitor.slow_pattern_threshold == 0.2
+    assert manager._performance_monitor.anomaly_emission_cooldown == 45.0
+    assert manager._performance_monitor.min_samples_for_anomaly == 25
     assert manager._semantic_threshold == 0.8
 
     SusPatternsManager._instance = None

--- a/tests/test_sync/test_ipinfo_lifecycle.py
+++ b/tests/test_sync/test_ipinfo_lifecycle.py
@@ -105,7 +105,6 @@ def test_ipinfo_refresh_logs_and_returns_when_download_fails(
 
 
 def test_ipinfo_download_database_uses_configured_ttl(tmp_path: Path) -> None:
-
     mgr = IPInfoManager(token="tok", db_path=tmp_path / "db.mmdb", max_age=7200)
     mgr.redis_handler = MagicMock()
     mgr.redis_handler.set_key = MagicMock()

--- a/tests/test_sync/test_ipinfo_lifecycle.py
+++ b/tests/test_sync/test_ipinfo_lifecycle.py
@@ -105,6 +105,7 @@ def test_ipinfo_refresh_logs_and_returns_when_download_fails(
 
 
 def test_ipinfo_download_database_uses_configured_ttl(tmp_path: Path) -> None:
+
     mgr = IPInfoManager(token="tok", db_path=tmp_path / "db.mmdb", max_age=7200)
     mgr.redis_handler = MagicMock()
     mgr.redis_handler.set_key = MagicMock()

--- a/tests/test_sync/test_sus_patterns/test_anomaly_scoring.py
+++ b/tests/test_sync/test_sus_patterns/test_anomaly_scoring.py
@@ -17,6 +17,35 @@ def test_threshold_field_default_and_bounds() -> None:
         SecurityConfig(detection_threat_score_threshold=-1.0)
 
 
+def test_anomaly_emission_cooldown_default_and_bounds() -> None:
+    assert SecurityConfig().detection_anomaly_emission_cooldown == 60.0
+    raised = SecurityConfig(detection_anomaly_emission_cooldown=300)
+    assert raised.detection_anomaly_emission_cooldown == 300
+    with pytest.raises(ValidationError):
+        SecurityConfig(detection_anomaly_emission_cooldown=0.5)
+    with pytest.raises(ValidationError):
+        SecurityConfig(detection_anomaly_emission_cooldown=4000.0)
+
+
+def test_min_samples_for_anomaly_default_and_bounds() -> None:
+    assert SecurityConfig().detection_min_samples_for_anomaly == 30
+    raised = SecurityConfig(detection_min_samples_for_anomaly=50)
+    assert raised.detection_min_samples_for_anomaly == 50
+    with pytest.raises(ValidationError):
+        SecurityConfig(detection_min_samples_for_anomaly=5)
+    with pytest.raises(ValidationError):
+        SecurityConfig(detection_min_samples_for_anomaly=2000)
+
+
+def test_new_detection_fields_round_trip() -> None:
+    config = SecurityConfig(
+        detection_anomaly_emission_cooldown=300,
+        detection_min_samples_for_anomaly=50,
+    )
+    assert config.detection_anomaly_emission_cooldown == 300
+    assert config.detection_min_samples_for_anomaly == 50
+
+
 def test_resolve_weight_defaults_to_category_one() -> None:
     assert _resolve_pattern_weight(r"some-pattern", "sqli") == 1.0
     assert DETECTION_CATEGORY_WEIGHTS["sqli"] == 1.0

--- a/tests/test_sync/test_sus_patterns/test_monitor.py
+++ b/tests/test_sync/test_sus_patterns/test_monitor.py
@@ -17,6 +17,7 @@ def test_initialization() -> None:
     assert monitor.history_size == 1000
     assert monitor.max_tracked_patterns == 1000
     assert monitor.anomaly_emission_cooldown == 60.0
+    assert monitor.min_samples_for_anomaly == 30
     assert len(monitor.pattern_stats) == 0
     assert len(monitor.recent_metrics) == 0
     assert len(monitor.anomaly_callbacks) == 0
@@ -27,12 +28,14 @@ def test_initialization() -> None:
         history_size=500,
         max_tracked_patterns=200,
         anomaly_emission_cooldown=30.0,
+        min_samples_for_anomaly=50,
     )
     assert monitor.anomaly_threshold == 5.0
     assert monitor.slow_pattern_threshold == 0.5
     assert monitor.history_size == 500
     assert monitor.max_tracked_patterns == 200
     assert monitor.anomaly_emission_cooldown == 30.0
+    assert monitor.min_samples_for_anomaly == 50
 
 
 def test_initialization_bounds() -> None:
@@ -42,12 +45,14 @@ def test_initialization_bounds() -> None:
         history_size=50,
         max_tracked_patterns=50,
         anomaly_emission_cooldown=0.1,
+        min_samples_for_anomaly=1,
     )
     assert monitor.anomaly_threshold == 1.0
     assert monitor.slow_pattern_threshold == 0.01
     assert monitor.history_size == 100
     assert monitor.max_tracked_patterns == 100
     assert monitor.anomaly_emission_cooldown == 1.0
+    assert monitor.min_samples_for_anomaly == 10
 
     monitor = PerformanceMonitor(
         anomaly_threshold=20.0,
@@ -55,12 +60,14 @@ def test_initialization_bounds() -> None:
         history_size=20000,
         max_tracked_patterns=10000,
         anomaly_emission_cooldown=10000.0,
+        min_samples_for_anomaly=5000,
     )
     assert monitor.anomaly_threshold == 10.0
     assert monitor.slow_pattern_threshold == 10.0
     assert monitor.history_size == 10000
     assert monitor.max_tracked_patterns == 5000
     assert monitor.anomaly_emission_cooldown == 3600.0
+    assert monitor.min_samples_for_anomaly == 1000
 
 
 def test_record_metric_pattern_truncation() -> None:
@@ -158,7 +165,7 @@ def test_check_anomalies_statistical() -> None:
     monitor.register_anomaly_callback(anomaly_callback)
 
     pattern = "stat_pattern"
-    for _ in range(20):
+    for _ in range(35):
         monitor.record_metric(
             pattern=pattern,
             execution_time=0.01,
@@ -213,7 +220,7 @@ def test_statistical_anomaly_zero_std_dev() -> None:
     monitor.register_anomaly_callback(anomaly_callback)
 
     pattern = "zero_std_pattern"
-    for _ in range(15):
+    for _ in range(35):
         monitor.record_metric(
             pattern=pattern,
             execution_time=0.01,
@@ -262,6 +269,17 @@ def test_statistical_anomaly_within_threshold() -> None:
         0.010,
         0.011,
         0.010,
+        0.009,
+        0.010,
+        0.011,
+        0.012,
+        0.009,
+        0.010,
+        0.011,
+        0.010,
+        0.009,
+        0.010,
+        0.011,
         0.009,
         0.010,
         0.011,
@@ -770,7 +788,7 @@ def test_statistical_anomaly_ignores_faster_than_average_execution() -> None:
 
     pattern = "fast_regression_pattern"
     stats = PatternStats(pattern=pattern)
-    stats.recent_times = deque([0.1] * 19 + [0.001], maxlen=100)
+    stats.recent_times = deque([0.1] * 30 + [0.001], maxlen=100)
     monitor.pattern_stats[pattern] = stats
 
     metric = PerformanceMetric(
@@ -792,7 +810,7 @@ def test_statistical_anomaly_detects_slower_than_average_execution() -> None:
 
     pattern = "slow_regression_pattern"
     stats = PatternStats(pattern=pattern)
-    stats.recent_times = deque([0.001] * 19 + [0.1], maxlen=100)
+    stats.recent_times = deque([0.001] * 30 + [0.1], maxlen=100)
     monitor.pattern_stats[pattern] = stats
 
     metric = PerformanceMetric(
@@ -822,7 +840,7 @@ def test_check_anomalies_statistical_ignores_fast_execution() -> None:
     monitor.register_anomaly_callback(anomaly_callback)
 
     pattern = "fast_stat_pattern"
-    for _ in range(20):
+    for _ in range(35):
         monitor.record_metric(
             pattern=pattern,
             execution_time=0.01,
@@ -970,3 +988,109 @@ def test_cooldown_state_does_not_survive_max_tracked_patterns_eviction() -> None
 def test_reserve_anomaly_emission_allows_untracked_pattern() -> None:
     monitor = PerformanceMonitor()
     assert monitor._reserve_anomaly_emission("never_recorded") is True
+
+
+def test_min_samples_for_anomaly_suppresses_below_floor() -> None:
+    monitor = PerformanceMonitor(
+        anomaly_threshold=2.0,
+        slow_pattern_threshold=1.0,
+        min_samples_for_anomaly=20,
+    )
+
+    anomalies_detected = []
+
+    def anomaly_callback(anomaly: dict[str, Any]) -> None:
+        anomalies_detected.append(anomaly)  # pragma: no cover
+
+    monitor.register_anomaly_callback(anomaly_callback)
+
+    pattern = "floor_pattern"
+    for _ in range(18):
+        monitor.record_metric(
+            pattern=pattern,
+            execution_time=0.01,
+            content_length=100,
+            matched=False,
+        )
+
+    monitor.record_metric(
+        pattern=pattern,
+        execution_time=0.5,
+        content_length=100,
+        matched=False,
+    )
+
+    assert len(anomalies_detected) == 0
+
+
+def test_min_samples_for_anomaly_fires_above_floor() -> None:
+    monitor = PerformanceMonitor(anomaly_threshold=2.0, min_samples_for_anomaly=20)
+
+    anomalies_detected = []
+
+    def anomaly_callback(anomaly: dict[str, Any]) -> None:
+        anomalies_detected.append(anomaly)
+
+    monitor.register_anomaly_callback(anomaly_callback)
+
+    pattern = "above_floor_pattern"
+    for _ in range(20):
+        monitor.record_metric(
+            pattern=pattern,
+            execution_time=0.01,
+            content_length=100,
+            matched=False,
+        )
+
+    anomalies_detected.clear()
+
+    monitor.record_metric(
+        pattern=pattern,
+        execution_time=0.5,
+        content_length=100,
+        matched=False,
+    )
+
+    statistical = [a for a in anomalies_detected if a["type"] == "statistical_anomaly"]
+    assert len(statistical) == 1
+    assert statistical[0]["z_score"] > 2.0
+
+
+def test_cooldown_is_configurable_via_constructor() -> None:
+    monitor = PerformanceMonitor(
+        slow_pattern_threshold=0.05, anomaly_emission_cooldown=5.0
+    )
+    agent_handler = MagicMock()
+    agent_handler.send_event = MagicMock()
+
+    clock = {"now": 1000.0}
+    with patch("time.monotonic", side_effect=lambda: clock["now"]):
+        monitor.record_metric(
+            pattern="stall_pattern",
+            execution_time=0.5,
+            content_length=100,
+            matched=False,
+            agent_handler=agent_handler,
+        )
+        assert agent_handler.send_event.call_count == 1
+
+        clock["now"] += 2.0
+        monitor.record_metric(
+            pattern="stall_pattern",
+            execution_time=0.5,
+            content_length=100,
+            matched=False,
+            agent_handler=agent_handler,
+        )
+        assert agent_handler.send_event.call_count == 1
+
+        clock["now"] += 5.0
+        monitor.record_metric(
+            pattern="stall_pattern",
+            execution_time=0.5,
+            content_length=100,
+            matched=False,
+            agent_handler=agent_handler,
+        )
+
+    assert agent_handler.send_event.call_count == 2

--- a/tests/test_sync/test_sus_patterns/test_sus_patterns.py
+++ b/tests/test_sync/test_sus_patterns/test_sus_patterns.py
@@ -213,6 +213,8 @@ def test_init_with_config() -> None:
     config.detection_slow_pattern_threshold = 0.2
     config.detection_monitor_history_size = 100
     config.detection_semantic_threshold = 0.8
+    config.detection_anomaly_emission_cooldown = 45.0
+    config.detection_min_samples_for_anomaly = 25
 
     SusPatternsManager._instance = None
     manager = SusPatternsManager(config)
@@ -226,6 +228,8 @@ def test_init_with_config() -> None:
     assert manager._performance_monitor is not None
     assert manager._performance_monitor.anomaly_threshold == 2.5
     assert manager._performance_monitor.slow_pattern_threshold == 0.2
+    assert manager._performance_monitor.anomaly_emission_cooldown == 45.0
+    assert manager._performance_monitor.min_samples_for_anomaly == 25
     assert manager._semantic_threshold == 0.8
 
     SusPatternsManager._instance = None


### PR DESCRIPTION
Stacks the 3.11.1 anomaly-detection tunables on top of #64 (the Azure IP-range fix, same 3.11.1 release).

## What
- Two new `SecurityConfig` fields: `detection_anomaly_emission_cooldown` (float, default 60.0, 1.0-3600.0) and `detection_min_samples_for_anomaly` (int, default 30, 10-1000).
- `PerformanceMonitor` gains `min_samples_for_anomaly` (clamped 10-1000); `_detect_statistical_anomaly` uses it instead of the hardcoded `< 10` floor. Default floor raised 10 to 30 to cut false fires on low-traffic apps.
- `_apply_enhanced_config` wires both fields into `PerformanceMonitor(...)`. The per-pattern `anomaly_emission_cooldown` was already a constructor param but was never passed from config (stuck at 60s); it is now configurable.
- Sync mirror regenerated; `make check-sync` clean.
- Dockerfile copies `scripts/` into the test image so `tests/test_lazy_reexports.py` (which loads `scripts/unasync.py`) passes under `make test` (docker). This was a pre-existing docker-only failure.
- 3.11.1 release notes filled in (CHANGELOG + docs/release-notes.md); the Azure bullet is untouched.

## Why
CatamountJack (design partner #2) reported the statistical-anomaly detector over-firing on his low-traffic app. The 10-sample floor plus high variance plus a non-configurable 60s cooldown produced noise. Both are now tunable; the default floor rises to 30.

## Verification
- Full docker suite: 4908 passed, 0 failed (includes the previously-failing `test_lazy_reexports`, now the Dockerfile copies `scripts/`).
- `make check-sync` OK; ruff, mypy, and lint-docs clean on touched files.

Stacked on #64. Merge #64 first, then this retargets to master.